### PR TITLE
chore: add CODEOWNERS for code-owner review on PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default reviewers for all paths
+*                       @kanfil @itaior
+
+# CI/CD workflow changes require maintainer review (supply-chain protection)
+/.github/workflows/     @kanfil @itaior


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning @kanfil and @itaior as required reviewers on all PRs, with an explicit rule for `.github/workflows/` (supply-chain protection — CI changes always need maintainer review).

**After merge:** branch protection will be updated to `require_code_owner_reviews: true`, giving this file teeth. Combined with the existing 1-approval rule + `enforce_admins`, this means even a stolen write/admin token cannot merge changes without a maintainer's review.

Context: part of the Aug 4 incident hardening (forged commits via stolen token — see HN thread).