### PR TITLE
feat: support external SDD_DOCS_LOCATION and shared team helpers across skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ Already have a directives repo? `team-setup` offers three other modes:
 - **Mode 2 — Point to existing local path** (wire a repo you already have)
 - **Mode 4 — Already configured** (verify an existing setup)
 
+### External SDD Docs Storage (optional)
+
+By default, all SDD artifacts (PDRs, ADRs, eval criteria, mission state, etc.) live under `.adlc/` in the project root. You can optionally keep them in a separate location — for example, a private specs repo, a compliance share, or a multi-repo consolidation directory — by setting `sdd_docs_location` in `.adlc/init-options.json`.
+
+Resolution order (highest to lowest precedence):
+1. `SDD_DOCS_LOCATION` environment variable
+2. `sdd_docs_location` field in `.adlc/init-options.json`
+3. Empty string (default to project root)
+
+Example `.adlc/init-options.json` with both team directives and external SDD docs:
+
+```json
+{
+  "team_ai_directives": "./team-ai-directives",
+  "sdd_docs_location": "~/sdd-docs"
+}
+```
+
+With the config above, a project named `my-service` writes its SDD artifacts to `~/sdd-docs/my-service/.adlc/...` and `~/sdd-docs/my-service/PRD.md`/`AD.md`, while the team AI directives repo remains at `./team-ai-directives`. **Important asymmetry**: `sdd_docs_location` uses a **per-project subfolder** (`{sdd_docs_location}/{project-name}/...`), but `team_ai_directives` is a **single shared top-level path** used as-is by every project that points to it. Do not conflate the two — one is a docs *storage root* with project isolation, the other is a shared *directives repository*.
+
 ---
 
 ## How It Works: Before vs. After ADLC
@@ -205,6 +225,7 @@ skills/
 ├── levelup/               # levelup-* (4 skills) + levelup-helpers.{sh,ps1}
 ├── mission-brief/         # core SDD orchestrator (1 skill)
 ├── evals/                 # evals-* (6 skills) + evals-templates/
+├── sdd-docs/              # sdd-docs-* (1 skill)
 ├── tech-radar/            # tech-radar-* (1 skill) + resources/radar.json
 ├── workspace/             # workspace (1 skill) — multi-repo coordination
 └── team/                  # team-* (6 skills) + team-helpers.{sh,ps1}
@@ -289,12 +310,28 @@ User-invoked. Multi-repo workspace coordination for shared team context.
 
 - **`workspace`** — Discover child repos at depth 1 and optionally link them as Git submodules, creating a multi-repo workspace analogous to VS Code's `.code-workspace`. The parent repo holds shared PDRs, ADRs, and CDRs under `.adlc/` (created by `product-specify`, `architect-specify`, `levelup-specify`); child implementation repos are linked for unified context. Commands: `/workspace` (discover), `/workspace --link` (register submodules), `/workspace --status` (audit: branch, dirty, unpushed, SHA drift). No `workspace.yml` — pure auto-discovery by convention. Say "Set up multi-repo workspace" or `/workspace --link`.
 
+### SDD Docs (1 skill)
+
+User-invoked. Publish SDD artifacts from their working location to the configured `sdd_docs_location` (or project root if unconfigured).
+
+- **`sdd-docs-publish`** — Compiles and publishes accepted PDRs, ADRs, eval criteria, PRD.md, AD.md, and mission audit trails to `sdd_docs_location`. Use `--ready` to create a PR instead of a draft. Say "Publish SDD docs."
+
+### Publishing SDD Docs
+
+`sdd-docs-publish` is the manual publishing step for external SDD docs storage. It follows the same git decision-tree pattern as `levelup-publish` (draft PR → push-only → local-only → git-init offer) and accepts a `--ready` flag to open a ready-for-review PR instead of a draft.
+
+**Publishing is not automatic — `product-implement`, `architect-implement`, `evals-implement`, and `mission-brief` never invoke git operations against `sdd_docs_location`.**
+
 ---
 
 <details>
 <summary><strong>Output File Layout</strong></summary>
 
-All skills write to `.adlc/` (project root) and the team AI directives repo.
+All skills write to `$SDD_ROOT/.adlc/` and `$SDD_ROOT/` (repo root), where `$SDD_ROOT` defaults to the project root and resolves to `{sdd_docs_location}/{project-name}/` when `sdd_docs_location` is configured. The paths below are shown relative to `$SDD_ROOT`.
+
+**Carve-outs (always project-local, unaffected by `sdd_docs_location`):**
+- The **Team Directives** bullets below (inside the `team_ai_directives` repository).
+- The `.adlc/init-options.json` bullet under **LevelUp**.
 
 **Team Directives** (inside the team AI directives repository):
 

--- a/skills/architect/architect-analyze/scripts/bash/common.sh
+++ b/skills/architect/architect-analyze/scripts/bash/common.sh
@@ -47,11 +47,53 @@ _seed_templates() {
     done
 }
 
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+# Uses the worktree root base name when inside a git worktree, otherwise the repo root base name.
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 # Emulates the get_feature_paths function from the Spec Kit common.sh.
 # The architect setup script evals this output to obtain REPO_ROOT.
 get_feature_paths() {
     local repo_root
     repo_root="$(_get_project_root)"
     _seed_templates "$repo_root"
+    local sdd_docs_location
+    sdd_docs_location=$(resolve_sdd_docs_location "$repo_root")
+    local sdd_root
+    if [[ -n "$sdd_docs_location" ]]; then
+        sdd_root="${sdd_docs_location}/$(sdd_project_subfolder_name "$repo_root")"
+    else
+        sdd_root="$repo_root"
+    fi
     echo "REPO_ROOT=\"$repo_root\""
+    echo "SDD_DOCS_LOCATION=\"$sdd_docs_location\""
+    echo "SDD_ROOT=\"$sdd_root\""
 }

--- a/skills/architect/architect-analyze/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-analyze/scripts/bash/setup-architect.sh
@@ -123,7 +123,7 @@ done
 
 # Default action if not specified
 if [[ -z "$ACTION" ]]; then
-    if [[ -f "$REPO_ROOT/AD.md" ]]; then
+    if [[ -f "$SDD_ROOT/AD.md" ]]; then
         ACTION="update"
     else
         ACTION="init"
@@ -131,11 +131,11 @@ if [[ -z "$ACTION" ]]; then
 fi
 
 # Ensure directories exist
-mkdir -p "$REPO_ROOT/.adlc/memory"
-mkdir -p "$REPO_ROOT/.adlc/drafts"
+mkdir -p "$SDD_ROOT/.adlc/memory"
+mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 # Architecture files (ADR Lifecycle)
-AD_FILE="$REPO_ROOT/AD.md"
+AD_FILE="$SDD_ROOT/AD.md"
 TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/architecture-template.md"
 AD_TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/AD-template.md"
 
@@ -599,7 +599,7 @@ parse_fm_title() {
 # Generate adr.md index from individual ADR files
 generate_adr_index() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
     local index_file="$adr_dir/adr.md"
 
     if [[ ! -d "$adr_dir" ]]; then
@@ -655,7 +655,7 @@ generate_adr_index() {
 get_adr_by_id() {
     local adr_id="$1"
     local scope="${2:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     # Normalize ID
     local numeric_id
@@ -675,7 +675,7 @@ get_adr_by_id() {
 # List all ADR IDs
 list_adrs() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | sed -E 's/.*ADR-([0-9]+)\.md/\1/' | sort -n
@@ -685,7 +685,7 @@ list_adrs() {
 # Get ADR count
 get_adr_count() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | wc -l
@@ -699,7 +699,7 @@ write_adr() {
     local adr_id="$1"
     local adr_content="$2"
     local scope="${3:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     mkdir -p "$adr_dir"
 
@@ -720,8 +720,8 @@ move_adr() {
     local from_scope="${2:-drafts}"
     local to_scope="${3:-memory}"
 
-    local from_dir="$REPO_ROOT/.adlc/$from_scope/adr"
-    local to_dir="$REPO_ROOT/.adlc/$to_scope/adr"
+    local from_dir="$SDD_ROOT/.adlc/$from_scope/adr"
+    local to_dir="$SDD_ROOT/.adlc/$to_scope/adr"
 
     local numeric_id
     numeric_id=$(echo "$adr_id" | sed -E 's/[^0-9]//g')
@@ -811,14 +811,14 @@ $diagram_code
 
 # Action: Specify (greenfield - interactive PRD exploration to create ADRs)
 action_specify() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "📐 Setting up for interactive ADR creation..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Show decomposition status
@@ -869,7 +869,7 @@ action_specify() {
     echo "After completion, run '/architect.implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
     fi
 }
 
@@ -879,10 +879,10 @@ action_clarify() {
 
 
     # Check drafts first (primary working location), fall back to memory if drafts is empty
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     local active_dir="$adr_dir"
     local active_dir="$adr_dir"
@@ -924,14 +924,14 @@ action_clarify() {
     echo "  5. Flag any inconsistencies or gaps" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Implement (generate full AD.md from ADRs)
 action_implement() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local ad_file="$REPO_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local ad_file="$SDD_ROOT/AD.md"
     local ad_template="$REPO_ROOT/.adlc/templates/AD-template.md"
     
     # Auto-migrate before checking
@@ -974,20 +974,20 @@ action_implement() {
     echo "  8. Clean up drafts if all ADRs are Accepted" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Initialize (brownfield - reverse-engineer from codebase, ADRs only)
 action_init() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "🔍 Initializing brownfield architecture discovery..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Scan existing docs for deduplication
@@ -1070,7 +1070,7 @@ action_init() {
     echo "      After clarification, run /architect.implement to generate AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
     fi
 }
 
@@ -1100,7 +1100,7 @@ action_map() {
     
     # Output structured data for AI agent to populate AD.md
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
     else
         echo "" >&2
         echo "📋 Mapping complete. Use this information to populate AD.md:" >&2
@@ -1158,7 +1158,7 @@ action_update() {
     echo "  - Add ADR if significant decision was made" >&2
     
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
     fi
 }
 
@@ -1224,7 +1224,7 @@ action_review() {
     fi
     
     # Check constitution alignment if it exists
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
     if [[ -f "$constitution_file" ]]; then
         echo "" >&2
         echo "📜 Checking constitution alignment..." >&2
@@ -1233,7 +1233,7 @@ action_review() {
     fi
     
     # Check for ADRs
-    local adr_mem_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_mem_dir="$SDD_ROOT/.adlc/memory/adr"
     if [[ -d "$adr_mem_dir" ]]; then
         echo "" >&2
         echo "📋 ADR directory found: $adr_mem_dir" >&2
@@ -1244,11 +1244,11 @@ action_review() {
     
     if $JSON_MODE; then
         if [[ ${#issues[@]} -eq 0 ]]; then
-            echo "{\"status\":\"success\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
         else
             # Format issues as JSON array
             issues_json=$(printf '%s\n' "${issues[@]}" | jq -R . | jq -s .)
-            echo "{\"status\":\"warning\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
+            echo "{\"status\":\"warning\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
         fi
     fi
 }
@@ -1261,10 +1261,10 @@ action_analyze() {
     # Auto-migrate before analysis
 
 
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
 
     local ad_exists=false
     local adr_exists=false
@@ -1332,16 +1332,16 @@ action_analyze() {
             feature_adrs_json=$(printf '%s\n' "${feature_adrs[@]}" | jq -R . | jq -s .)
         fi
 
-        echo "{\"status\":\"success\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Plan DAG (Phase 1 of implement - generate execution plan)
 action_plan_dag() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
 
     echo "📐 DAG Planning Phase" >&2
     echo "" >&2
@@ -1358,7 +1358,7 @@ action_plan_dag() {
     fi
 
     # Ensure directories exist
-    mkdir -p "$REPO_ROOT/.adlc/architect"
+    mkdir -p "$SDD_ROOT/.adlc/architect"
     mkdir -p "$views_dir"
 
     # Extract unique sub-systems from ADR files
@@ -1432,14 +1432,14 @@ action_plan_dag() {
         done
         subsystems_json+="]"
 
-        echo "{\"status\":\"success\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Execute DAG (Phase 2 of implement - generate views based on state)
 action_execute_dag() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
     
     echo "🔧 DAG Execution Phase" >&2
     echo "" >&2
@@ -1470,19 +1470,19 @@ action_execute_dag() {
         if [[ -f "$state_file" ]]; then
             local state_content
             state_content=$(cat "$state_file")
-            echo "{\"status\":\"success\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
         else
-            echo "{\"status\":\"error\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
+            echo "{\"status\":\"error\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
         fi
     fi
 }
 
 # Action: Summarize (Phase 3 of implement - aggregate views into AD.md)
 action_summarize() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     
     echo "📝 Summarization Phase" >&2
     echo "" >&2
@@ -1536,14 +1536,14 @@ action_summarize() {
         done < <(find "$views_dir" -name "*.md" -type f 2>/dev/null)
         views_json+="]"
         
-        echo "{\"status\":\"success\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
     fi
 }
 
 # Action: Validate (READ-ONLY architecture validation for plan alignment)
 action_validate() {
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     echo "🔍 Architecture Validation Mode (READ-ONLY)" >&2
     echo ""
@@ -1558,7 +1558,7 @@ action_validate() {
         echo "⏭️  Architecture not found: $adr_dir" >&2
         echo "     Skipping validation gracefully" >&2
         if $JSON_MODE; then
-            echo "{\"status\":\"skipped\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
+            echo "{\"status\":\"skipped\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
         fi
         exit 0
     fi
@@ -1574,7 +1574,7 @@ action_validate() {
     echo "  4. Report findings (READ-ONLY, no modifications)" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 

--- a/skills/architect/architect-analyze/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-analyze/scripts/powershell/setup-architect.ps1
@@ -105,6 +105,35 @@ function Seed-Templates {
     }
 }
 
+
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+function Resolve-SddDocsLocation {
+    param([string]$ProjectRoot)
+    $loc = $env:SDD_DOCS_LOCATION
+    if ($loc) { return $loc }
+    $optionsFile = Join-Path $ProjectRoot ".adlc\init-options.json"
+    if (Test-Path $optionsFile) {
+        try {
+            $options = Get-Content $optionsFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            if ($options.sdd_docs_location) { return $options.sdd_docs_location }
+        } catch { }
+    }
+    return ""
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+function Get-SddProjectSubfolderName {
+    param([string]$ProjectRoot)
+    try {
+        $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+        if ($commonDir) {
+            return (Split-Path (Resolve-Path (Join-Path $commonDir "..")).Path -Leaf)
+        }
+    } catch { }
+    return (Split-Path $ProjectRoot -Leaf)
+}
+
 # Detect tech stack from codebase
 function Get-TechStack {
     Write-Host "Scanning codebase for technology stack..." -ForegroundColor Cyan
@@ -520,7 +549,7 @@ function New-ArchitectureDiagrams {
 function Invoke-Specify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "📐 Setting up for interactive ADR creation..." -ForegroundColor Cyan
@@ -537,7 +566,7 @@ function Invoke-Specify {
     }
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -587,7 +616,7 @@ function Invoke-Specify {
     Write-Host "After completion, run '/architect.implement' to generate full AD.md"
     
     if ($Json) {
-        @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
     }
 }
 
@@ -595,7 +624,7 @@ function Invoke-Specify {
 function Invoke-Clarify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
         Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
@@ -617,7 +646,7 @@ function Invoke-Clarify {
     Write-Host "  4. Flag any inconsistencies or gaps"
     
     if ($Json) {
-        @{status="success"; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -625,8 +654,8 @@ function Invoke-Clarify {
 function Invoke-Implement {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $adFile = Join-Path $repoRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
@@ -665,21 +694,21 @@ function Invoke-Implement {
     Write-Host "  7. Clean up drafts if all ADRs are Accepted"
     
     if ($Json) {
-        @{status="success"; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
 # Initialize action (brownfield - reverse-engineer from codebase, ADRs only)
 function Invoke-Init {
-    param($repoRoot, $contextArgs)
+    param($repoRoot, $sddRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "🔍 Initializing brownfield architecture discovery..." -ForegroundColor Cyan
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -770,7 +799,7 @@ function Invoke-Init {
     
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="init"
             adr_dir=$adrDir
             tech_stack=$techStack
@@ -812,7 +841,7 @@ function Invoke-Map {
     # Output structured data for AI agent to populate AD.md Section C
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="map"
             tech_stack=$techStack
             directory_structure=$dirStructure
@@ -866,7 +895,7 @@ function Invoke-Update {
     Write-Host "  - Add ADR if significant decision was made"
     
     if ($Json) {
-        @{status="success"; action="update"; file=$architectureFile} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="update"; file=$architectureFile} | ConvertTo-Json
     }
 }
 
@@ -933,10 +962,10 @@ function Invoke-Review {
     }
     
     # Check constitution alignment (new path: memory/constitution.md)
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     if (-not (Test-Path $constitutionFile)) {
         # Fallback to legacy path
-        $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+        $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     }
     if (Test-Path $constitutionFile) {
         Write-Host ""
@@ -947,9 +976,9 @@ function Invoke-Review {
     
     if ($Json) {
         if ($issues.Count -eq 0) {
-            @{status="success"; action="review"; issues=@()} | ConvertTo-Json
+            @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=@()} | ConvertTo-Json
         } else {
-            @{status="warning"; action="review"; issues=$issues} | ConvertTo-Json
+            @{status="warning"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=$issues} | ConvertTo-Json
         }
     }
 }
@@ -958,15 +987,16 @@ function Invoke-Review {
 function Invoke-Analyze {
     param(
         [string]$repoRoot,
+        [string]$sddRoot,
         [string[]]$contextArgs
     )
     
     Write-Host "🔍 Architecture Analysis Mode" -ForegroundColor Cyan
     Write-Host ""
     
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     
     $adExists = Test-Path $adFile
     $adrExists = Test-Path $adrDir
@@ -1016,7 +1046,7 @@ function Invoke-Analyze {
     
     if ($Json) {
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "analyze"
             ad_file = $adFile
             ad_exists = $adExists
@@ -1035,7 +1065,7 @@ function Invoke-Analyze {
 function Invoke-Validate {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     Write-Host "🔍 Architecture Validation Mode (READ-ONLY)" -ForegroundColor Cyan
     Write-Host ""
@@ -1045,7 +1075,7 @@ function Invoke-Validate {
         Write-Host "⏭️  Architecture not found: $adrDir" -ForegroundColor Yellow
         Write-Host "     Skipping validation gracefully" -ForegroundColor Gray
         if ($Json) {
-            @{status="skipped"; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
+            @{status="skipped"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
         }
         exit 0
     }
@@ -1063,7 +1093,7 @@ function Invoke-Validate {
     Write-Host "  4. Report findings (READ-ONLY, no modifications)"
     
     if ($Json) {
-        @{status="success"; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -1071,9 +1101,9 @@ function Invoke-Validate {
 function Invoke-PlanDag {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "📐 DAG Planning Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1085,7 +1115,7 @@ function Invoke-PlanDag {
     }
     
     # Ensure directories exist
-    $architectDir = Join-Path $repoRoot ".adlc\architect"
+    $architectDir = Join-Path $sddRoot ".adlc\architect"
     if (-not (Test-Path $architectDir)) {
         New-Item -ItemType Directory -Path $architectDir -Force | Out-Null
     }
@@ -1136,7 +1166,7 @@ function Invoke-PlanDag {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "plan-dag"
             adr_dir = $adrDir
             state_file = $stateFile
@@ -1152,8 +1182,8 @@ function Invoke-PlanDag {
 function Invoke-ExecuteDag {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "🔧 DAG Execution Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1183,7 +1213,7 @@ function Invoke-ExecuteDag {
     if ($Json) {
         $stateContent = Get-Content $stateFile -Raw | ConvertFrom-Json
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "execute-dag"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1196,10 +1226,10 @@ function Invoke-ExecuteDag {
 function Invoke-Summarize {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
     
     Write-Host "📝 Summarization Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1244,7 +1274,7 @@ function Invoke-Summarize {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "summarize"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1261,15 +1291,23 @@ try {
     $repoRoot = Get-RepositoryRoot
     Seed-Templates -RepoRoot $repoRoot
 
+    # Resolve external SDD docs location
+    $sddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $repoRoot
+    $sddRoot = if ($sddDocsLocation) {
+        Join-Path $sddDocsLocation (Get-SddProjectSubfolderName -ProjectRoot $repoRoot)
+    } else {
+        $repoRoot
+    }
+
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
     
     # Architecture files (new structure: AD.md at root, ADRs in memory/)
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $templateFile = Join-Path $repoRoot ".adlc\templates\architecture-template.md"
     $adTemplateFile = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
@@ -1289,40 +1327,40 @@ try {
     # Execute action
     switch ($Action) {
         'specify' {
-            Invoke-Specify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Specify -repoRoot $sddRoot -contextArgs $Context
         }
         'clarify' {
-            Invoke-Clarify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Clarify -repoRoot $sddRoot -contextArgs $Context
         }
         'init' {
-            Invoke-Init -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Init -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'map' {
             Invoke-Map -repoRoot $repoRoot
         }
         'implement' {
-            Invoke-Implement -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Implement -repoRoot $sddRoot -contextArgs $Context
         }
         'analyze' {
-            Invoke-Analyze -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Analyze -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'validate' {
-            Invoke-Validate -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Validate -repoRoot $sddRoot -contextArgs $Context
         }
         'plan-dag' {
-            Invoke-PlanDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-PlanDag -repoRoot $sddRoot -contextArgs $Context
         }
         'execute-dag' {
-            Invoke-ExecuteDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-ExecuteDag -repoRoot $sddRoot -contextArgs $Context
         }
         'summarize' {
-            Invoke-Summarize -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Summarize -repoRoot $sddRoot -contextArgs $Context
         }
         'update' {
-            Invoke-Update -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Update -repoRoot $sddRoot -architectureFile $adFile
         }
         'review' {
-            Invoke-Review -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Review -repoRoot $sddRoot -architectureFile $adFile
         }
         default {
             Write-Error "Unknown action: $Action`nUse -Help for usage information"

--- a/skills/architect/architect-clarify/scripts/bash/common.sh
+++ b/skills/architect/architect-clarify/scripts/bash/common.sh
@@ -47,11 +47,53 @@ _seed_templates() {
     done
 }
 
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+# Uses the worktree root base name when inside a git worktree, otherwise the repo root base name.
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 # Emulates the get_feature_paths function from the Spec Kit common.sh.
 # The architect setup script evals this output to obtain REPO_ROOT.
 get_feature_paths() {
     local repo_root
     repo_root="$(_get_project_root)"
     _seed_templates "$repo_root"
+    local sdd_docs_location
+    sdd_docs_location=$(resolve_sdd_docs_location "$repo_root")
+    local sdd_root
+    if [[ -n "$sdd_docs_location" ]]; then
+        sdd_root="${sdd_docs_location}/$(sdd_project_subfolder_name "$repo_root")"
+    else
+        sdd_root="$repo_root"
+    fi
     echo "REPO_ROOT=\"$repo_root\""
+    echo "SDD_DOCS_LOCATION=\"$sdd_docs_location\""
+    echo "SDD_ROOT=\"$sdd_root\""
 }

--- a/skills/architect/architect-clarify/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-clarify/scripts/bash/setup-architect.sh
@@ -123,7 +123,7 @@ done
 
 # Default action if not specified
 if [[ -z "$ACTION" ]]; then
-    if [[ -f "$REPO_ROOT/AD.md" ]]; then
+    if [[ -f "$SDD_ROOT/AD.md" ]]; then
         ACTION="update"
     else
         ACTION="init"
@@ -131,11 +131,11 @@ if [[ -z "$ACTION" ]]; then
 fi
 
 # Ensure directories exist
-mkdir -p "$REPO_ROOT/.adlc/memory"
-mkdir -p "$REPO_ROOT/.adlc/drafts"
+mkdir -p "$SDD_ROOT/.adlc/memory"
+mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 # Architecture files (ADR Lifecycle)
-AD_FILE="$REPO_ROOT/AD.md"
+AD_FILE="$SDD_ROOT/AD.md"
 TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/architecture-template.md"
 AD_TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/AD-template.md"
 
@@ -599,7 +599,7 @@ parse_fm_title() {
 # Generate adr.md index from individual ADR files
 generate_adr_index() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
     local index_file="$adr_dir/adr.md"
 
     if [[ ! -d "$adr_dir" ]]; then
@@ -655,7 +655,7 @@ generate_adr_index() {
 get_adr_by_id() {
     local adr_id="$1"
     local scope="${2:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     # Normalize ID
     local numeric_id
@@ -675,7 +675,7 @@ get_adr_by_id() {
 # List all ADR IDs
 list_adrs() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | sed -E 's/.*ADR-([0-9]+)\.md/\1/' | sort -n
@@ -685,7 +685,7 @@ list_adrs() {
 # Get ADR count
 get_adr_count() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | wc -l
@@ -699,7 +699,7 @@ write_adr() {
     local adr_id="$1"
     local adr_content="$2"
     local scope="${3:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     mkdir -p "$adr_dir"
 
@@ -720,8 +720,8 @@ move_adr() {
     local from_scope="${2:-drafts}"
     local to_scope="${3:-memory}"
 
-    local from_dir="$REPO_ROOT/.adlc/$from_scope/adr"
-    local to_dir="$REPO_ROOT/.adlc/$to_scope/adr"
+    local from_dir="$SDD_ROOT/.adlc/$from_scope/adr"
+    local to_dir="$SDD_ROOT/.adlc/$to_scope/adr"
 
     local numeric_id
     numeric_id=$(echo "$adr_id" | sed -E 's/[^0-9]//g')
@@ -811,14 +811,14 @@ $diagram_code
 
 # Action: Specify (greenfield - interactive PRD exploration to create ADRs)
 action_specify() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "📐 Setting up for interactive ADR creation..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Show decomposition status
@@ -869,7 +869,7 @@ action_specify() {
     echo "After completion, run '/architect.implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
     fi
 }
 
@@ -879,10 +879,10 @@ action_clarify() {
 
 
     # Check drafts first (primary working location), fall back to memory if drafts is empty
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     local active_dir="$adr_dir"
     local active_dir="$adr_dir"
@@ -924,14 +924,14 @@ action_clarify() {
     echo "  5. Flag any inconsistencies or gaps" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Implement (generate full AD.md from ADRs)
 action_implement() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local ad_file="$REPO_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local ad_file="$SDD_ROOT/AD.md"
     local ad_template="$REPO_ROOT/.adlc/templates/AD-template.md"
     
     # Auto-migrate before checking
@@ -974,20 +974,20 @@ action_implement() {
     echo "  8. Clean up drafts if all ADRs are Accepted" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Initialize (brownfield - reverse-engineer from codebase, ADRs only)
 action_init() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "🔍 Initializing brownfield architecture discovery..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Scan existing docs for deduplication
@@ -1070,7 +1070,7 @@ action_init() {
     echo "      After clarification, run /architect.implement to generate AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
     fi
 }
 
@@ -1100,7 +1100,7 @@ action_map() {
     
     # Output structured data for AI agent to populate AD.md
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
     else
         echo "" >&2
         echo "📋 Mapping complete. Use this information to populate AD.md:" >&2
@@ -1158,7 +1158,7 @@ action_update() {
     echo "  - Add ADR if significant decision was made" >&2
     
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
     fi
 }
 
@@ -1224,7 +1224,7 @@ action_review() {
     fi
     
     # Check constitution alignment if it exists
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
     if [[ -f "$constitution_file" ]]; then
         echo "" >&2
         echo "📜 Checking constitution alignment..." >&2
@@ -1233,7 +1233,7 @@ action_review() {
     fi
     
     # Check for ADRs
-    local adr_mem_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_mem_dir="$SDD_ROOT/.adlc/memory/adr"
     if [[ -d "$adr_mem_dir" ]]; then
         echo "" >&2
         echo "📋 ADR directory found: $adr_mem_dir" >&2
@@ -1244,11 +1244,11 @@ action_review() {
     
     if $JSON_MODE; then
         if [[ ${#issues[@]} -eq 0 ]]; then
-            echo "{\"status\":\"success\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
         else
             # Format issues as JSON array
             issues_json=$(printf '%s\n' "${issues[@]}" | jq -R . | jq -s .)
-            echo "{\"status\":\"warning\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
+            echo "{\"status\":\"warning\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
         fi
     fi
 }
@@ -1261,10 +1261,10 @@ action_analyze() {
     # Auto-migrate before analysis
 
 
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
 
     local ad_exists=false
     local adr_exists=false
@@ -1332,16 +1332,16 @@ action_analyze() {
             feature_adrs_json=$(printf '%s\n' "${feature_adrs[@]}" | jq -R . | jq -s .)
         fi
 
-        echo "{\"status\":\"success\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Plan DAG (Phase 1 of implement - generate execution plan)
 action_plan_dag() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
 
     echo "📐 DAG Planning Phase" >&2
     echo "" >&2
@@ -1358,7 +1358,7 @@ action_plan_dag() {
     fi
 
     # Ensure directories exist
-    mkdir -p "$REPO_ROOT/.adlc/architect"
+    mkdir -p "$SDD_ROOT/.adlc/architect"
     mkdir -p "$views_dir"
 
     # Extract unique sub-systems from ADR files
@@ -1432,14 +1432,14 @@ action_plan_dag() {
         done
         subsystems_json+="]"
 
-        echo "{\"status\":\"success\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Execute DAG (Phase 2 of implement - generate views based on state)
 action_execute_dag() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
     
     echo "🔧 DAG Execution Phase" >&2
     echo "" >&2
@@ -1470,19 +1470,19 @@ action_execute_dag() {
         if [[ -f "$state_file" ]]; then
             local state_content
             state_content=$(cat "$state_file")
-            echo "{\"status\":\"success\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
         else
-            echo "{\"status\":\"error\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
+            echo "{\"status\":\"error\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
         fi
     fi
 }
 
 # Action: Summarize (Phase 3 of implement - aggregate views into AD.md)
 action_summarize() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     
     echo "📝 Summarization Phase" >&2
     echo "" >&2
@@ -1536,14 +1536,14 @@ action_summarize() {
         done < <(find "$views_dir" -name "*.md" -type f 2>/dev/null)
         views_json+="]"
         
-        echo "{\"status\":\"success\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
     fi
 }
 
 # Action: Validate (READ-ONLY architecture validation for plan alignment)
 action_validate() {
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     echo "🔍 Architecture Validation Mode (READ-ONLY)" >&2
     echo ""
@@ -1558,7 +1558,7 @@ action_validate() {
         echo "⏭️  Architecture not found: $adr_dir" >&2
         echo "     Skipping validation gracefully" >&2
         if $JSON_MODE; then
-            echo "{\"status\":\"skipped\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
+            echo "{\"status\":\"skipped\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
         fi
         exit 0
     fi
@@ -1574,7 +1574,7 @@ action_validate() {
     echo "  4. Report findings (READ-ONLY, no modifications)" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 

--- a/skills/architect/architect-clarify/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-clarify/scripts/powershell/setup-architect.ps1
@@ -105,6 +105,35 @@ function Seed-Templates {
     }
 }
 
+
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+function Resolve-SddDocsLocation {
+    param([string]$ProjectRoot)
+    $loc = $env:SDD_DOCS_LOCATION
+    if ($loc) { return $loc }
+    $optionsFile = Join-Path $ProjectRoot ".adlc\init-options.json"
+    if (Test-Path $optionsFile) {
+        try {
+            $options = Get-Content $optionsFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            if ($options.sdd_docs_location) { return $options.sdd_docs_location }
+        } catch { }
+    }
+    return ""
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+function Get-SddProjectSubfolderName {
+    param([string]$ProjectRoot)
+    try {
+        $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+        if ($commonDir) {
+            return (Split-Path (Resolve-Path (Join-Path $commonDir "..")).Path -Leaf)
+        }
+    } catch { }
+    return (Split-Path $ProjectRoot -Leaf)
+}
+
 # Detect tech stack from codebase
 function Get-TechStack {
     Write-Host "Scanning codebase for technology stack..." -ForegroundColor Cyan
@@ -520,7 +549,7 @@ function New-ArchitectureDiagrams {
 function Invoke-Specify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "📐 Setting up for interactive ADR creation..." -ForegroundColor Cyan
@@ -537,7 +566,7 @@ function Invoke-Specify {
     }
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -587,7 +616,7 @@ function Invoke-Specify {
     Write-Host "After completion, run '/architect.implement' to generate full AD.md"
     
     if ($Json) {
-        @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
     }
 }
 
@@ -595,7 +624,7 @@ function Invoke-Specify {
 function Invoke-Clarify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
         Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
@@ -617,7 +646,7 @@ function Invoke-Clarify {
     Write-Host "  4. Flag any inconsistencies or gaps"
     
     if ($Json) {
-        @{status="success"; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -625,8 +654,8 @@ function Invoke-Clarify {
 function Invoke-Implement {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $adFile = Join-Path $repoRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
@@ -665,21 +694,21 @@ function Invoke-Implement {
     Write-Host "  7. Clean up drafts if all ADRs are Accepted"
     
     if ($Json) {
-        @{status="success"; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
 # Initialize action (brownfield - reverse-engineer from codebase, ADRs only)
 function Invoke-Init {
-    param($repoRoot, $contextArgs)
+    param($repoRoot, $sddRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "🔍 Initializing brownfield architecture discovery..." -ForegroundColor Cyan
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -770,7 +799,7 @@ function Invoke-Init {
     
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="init"
             adr_dir=$adrDir
             tech_stack=$techStack
@@ -812,7 +841,7 @@ function Invoke-Map {
     # Output structured data for AI agent to populate AD.md Section C
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="map"
             tech_stack=$techStack
             directory_structure=$dirStructure
@@ -866,7 +895,7 @@ function Invoke-Update {
     Write-Host "  - Add ADR if significant decision was made"
     
     if ($Json) {
-        @{status="success"; action="update"; file=$architectureFile} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="update"; file=$architectureFile} | ConvertTo-Json
     }
 }
 
@@ -933,10 +962,10 @@ function Invoke-Review {
     }
     
     # Check constitution alignment (new path: memory/constitution.md)
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     if (-not (Test-Path $constitutionFile)) {
         # Fallback to legacy path
-        $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+        $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     }
     if (Test-Path $constitutionFile) {
         Write-Host ""
@@ -947,9 +976,9 @@ function Invoke-Review {
     
     if ($Json) {
         if ($issues.Count -eq 0) {
-            @{status="success"; action="review"; issues=@()} | ConvertTo-Json
+            @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=@()} | ConvertTo-Json
         } else {
-            @{status="warning"; action="review"; issues=$issues} | ConvertTo-Json
+            @{status="warning"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=$issues} | ConvertTo-Json
         }
     }
 }
@@ -958,15 +987,16 @@ function Invoke-Review {
 function Invoke-Analyze {
     param(
         [string]$repoRoot,
+        [string]$sddRoot,
         [string[]]$contextArgs
     )
     
     Write-Host "🔍 Architecture Analysis Mode" -ForegroundColor Cyan
     Write-Host ""
     
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     
     $adExists = Test-Path $adFile
     $adrExists = Test-Path $adrDir
@@ -1016,7 +1046,7 @@ function Invoke-Analyze {
     
     if ($Json) {
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "analyze"
             ad_file = $adFile
             ad_exists = $adExists
@@ -1035,7 +1065,7 @@ function Invoke-Analyze {
 function Invoke-Validate {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     Write-Host "🔍 Architecture Validation Mode (READ-ONLY)" -ForegroundColor Cyan
     Write-Host ""
@@ -1045,7 +1075,7 @@ function Invoke-Validate {
         Write-Host "⏭️  Architecture not found: $adrDir" -ForegroundColor Yellow
         Write-Host "     Skipping validation gracefully" -ForegroundColor Gray
         if ($Json) {
-            @{status="skipped"; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
+            @{status="skipped"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
         }
         exit 0
     }
@@ -1063,7 +1093,7 @@ function Invoke-Validate {
     Write-Host "  4. Report findings (READ-ONLY, no modifications)"
     
     if ($Json) {
-        @{status="success"; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -1071,9 +1101,9 @@ function Invoke-Validate {
 function Invoke-PlanDag {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "📐 DAG Planning Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1085,7 +1115,7 @@ function Invoke-PlanDag {
     }
     
     # Ensure directories exist
-    $architectDir = Join-Path $repoRoot ".adlc\architect"
+    $architectDir = Join-Path $sddRoot ".adlc\architect"
     if (-not (Test-Path $architectDir)) {
         New-Item -ItemType Directory -Path $architectDir -Force | Out-Null
     }
@@ -1136,7 +1166,7 @@ function Invoke-PlanDag {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "plan-dag"
             adr_dir = $adrDir
             state_file = $stateFile
@@ -1152,8 +1182,8 @@ function Invoke-PlanDag {
 function Invoke-ExecuteDag {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "🔧 DAG Execution Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1183,7 +1213,7 @@ function Invoke-ExecuteDag {
     if ($Json) {
         $stateContent = Get-Content $stateFile -Raw | ConvertFrom-Json
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "execute-dag"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1196,10 +1226,10 @@ function Invoke-ExecuteDag {
 function Invoke-Summarize {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
     
     Write-Host "📝 Summarization Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1244,7 +1274,7 @@ function Invoke-Summarize {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "summarize"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1261,15 +1291,23 @@ try {
     $repoRoot = Get-RepositoryRoot
     Seed-Templates -RepoRoot $repoRoot
 
+    # Resolve external SDD docs location
+    $sddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $repoRoot
+    $sddRoot = if ($sddDocsLocation) {
+        Join-Path $sddDocsLocation (Get-SddProjectSubfolderName -ProjectRoot $repoRoot)
+    } else {
+        $repoRoot
+    }
+
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
     
     # Architecture files (new structure: AD.md at root, ADRs in memory/)
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $templateFile = Join-Path $repoRoot ".adlc\templates\architecture-template.md"
     $adTemplateFile = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
@@ -1289,40 +1327,40 @@ try {
     # Execute action
     switch ($Action) {
         'specify' {
-            Invoke-Specify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Specify -repoRoot $sddRoot -contextArgs $Context
         }
         'clarify' {
-            Invoke-Clarify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Clarify -repoRoot $sddRoot -contextArgs $Context
         }
         'init' {
-            Invoke-Init -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Init -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'map' {
             Invoke-Map -repoRoot $repoRoot
         }
         'implement' {
-            Invoke-Implement -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Implement -repoRoot $sddRoot -contextArgs $Context
         }
         'analyze' {
-            Invoke-Analyze -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Analyze -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'validate' {
-            Invoke-Validate -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Validate -repoRoot $sddRoot -contextArgs $Context
         }
         'plan-dag' {
-            Invoke-PlanDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-PlanDag -repoRoot $sddRoot -contextArgs $Context
         }
         'execute-dag' {
-            Invoke-ExecuteDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-ExecuteDag -repoRoot $sddRoot -contextArgs $Context
         }
         'summarize' {
-            Invoke-Summarize -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Summarize -repoRoot $sddRoot -contextArgs $Context
         }
         'update' {
-            Invoke-Update -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Update -repoRoot $sddRoot -architectureFile $adFile
         }
         'review' {
-            Invoke-Review -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Review -repoRoot $sddRoot -architectureFile $adFile
         }
         default {
             Write-Error "Unknown action: $Action`nUse -Help for usage information"

--- a/skills/architect/architect-implement/scripts/bash/common.sh
+++ b/skills/architect/architect-implement/scripts/bash/common.sh
@@ -47,11 +47,53 @@ _seed_templates() {
     done
 }
 
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+# Uses the worktree root base name when inside a git worktree, otherwise the repo root base name.
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 # Emulates the get_feature_paths function from the Spec Kit common.sh.
 # The architect setup script evals this output to obtain REPO_ROOT.
 get_feature_paths() {
     local repo_root
     repo_root="$(_get_project_root)"
     _seed_templates "$repo_root"
+    local sdd_docs_location
+    sdd_docs_location=$(resolve_sdd_docs_location "$repo_root")
+    local sdd_root
+    if [[ -n "$sdd_docs_location" ]]; then
+        sdd_root="${sdd_docs_location}/$(sdd_project_subfolder_name "$repo_root")"
+    else
+        sdd_root="$repo_root"
+    fi
     echo "REPO_ROOT=\"$repo_root\""
+    echo "SDD_DOCS_LOCATION=\"$sdd_docs_location\""
+    echo "SDD_ROOT=\"$sdd_root\""
 }

--- a/skills/architect/architect-implement/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-implement/scripts/bash/setup-architect.sh
@@ -123,7 +123,7 @@ done
 
 # Default action if not specified
 if [[ -z "$ACTION" ]]; then
-    if [[ -f "$REPO_ROOT/AD.md" ]]; then
+    if [[ -f "$SDD_ROOT/AD.md" ]]; then
         ACTION="update"
     else
         ACTION="init"
@@ -131,11 +131,11 @@ if [[ -z "$ACTION" ]]; then
 fi
 
 # Ensure directories exist
-mkdir -p "$REPO_ROOT/.adlc/memory"
-mkdir -p "$REPO_ROOT/.adlc/drafts"
+mkdir -p "$SDD_ROOT/.adlc/memory"
+mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 # Architecture files (ADR Lifecycle)
-AD_FILE="$REPO_ROOT/AD.md"
+AD_FILE="$SDD_ROOT/AD.md"
 TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/architecture-template.md"
 AD_TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/AD-template.md"
 
@@ -599,7 +599,7 @@ parse_fm_title() {
 # Generate adr.md index from individual ADR files
 generate_adr_index() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
     local index_file="$adr_dir/adr.md"
 
     if [[ ! -d "$adr_dir" ]]; then
@@ -655,7 +655,7 @@ generate_adr_index() {
 get_adr_by_id() {
     local adr_id="$1"
     local scope="${2:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     # Normalize ID
     local numeric_id
@@ -675,7 +675,7 @@ get_adr_by_id() {
 # List all ADR IDs
 list_adrs() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | sed -E 's/.*ADR-([0-9]+)\.md/\1/' | sort -n
@@ -685,7 +685,7 @@ list_adrs() {
 # Get ADR count
 get_adr_count() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | wc -l
@@ -699,7 +699,7 @@ write_adr() {
     local adr_id="$1"
     local adr_content="$2"
     local scope="${3:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     mkdir -p "$adr_dir"
 
@@ -720,8 +720,8 @@ move_adr() {
     local from_scope="${2:-drafts}"
     local to_scope="${3:-memory}"
 
-    local from_dir="$REPO_ROOT/.adlc/$from_scope/adr"
-    local to_dir="$REPO_ROOT/.adlc/$to_scope/adr"
+    local from_dir="$SDD_ROOT/.adlc/$from_scope/adr"
+    local to_dir="$SDD_ROOT/.adlc/$to_scope/adr"
 
     local numeric_id
     numeric_id=$(echo "$adr_id" | sed -E 's/[^0-9]//g')
@@ -811,14 +811,14 @@ $diagram_code
 
 # Action: Specify (greenfield - interactive PRD exploration to create ADRs)
 action_specify() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "📐 Setting up for interactive ADR creation..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Show decomposition status
@@ -869,7 +869,7 @@ action_specify() {
     echo "After completion, run '/architect.implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
     fi
 }
 
@@ -879,10 +879,10 @@ action_clarify() {
 
 
     # Check drafts first (primary working location), fall back to memory if drafts is empty
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     local active_dir="$adr_dir"
     local active_dir="$adr_dir"
@@ -924,14 +924,14 @@ action_clarify() {
     echo "  5. Flag any inconsistencies or gaps" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Implement (generate full AD.md from ADRs)
 action_implement() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local ad_file="$REPO_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local ad_file="$SDD_ROOT/AD.md"
     local ad_template="$REPO_ROOT/.adlc/templates/AD-template.md"
     
     # Auto-migrate before checking
@@ -974,20 +974,20 @@ action_implement() {
     echo "  8. Clean up drafts if all ADRs are Accepted" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Initialize (brownfield - reverse-engineer from codebase, ADRs only)
 action_init() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "🔍 Initializing brownfield architecture discovery..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Scan existing docs for deduplication
@@ -1070,7 +1070,7 @@ action_init() {
     echo "      After clarification, run /architect.implement to generate AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
     fi
 }
 
@@ -1100,7 +1100,7 @@ action_map() {
     
     # Output structured data for AI agent to populate AD.md
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
     else
         echo "" >&2
         echo "📋 Mapping complete. Use this information to populate AD.md:" >&2
@@ -1158,7 +1158,7 @@ action_update() {
     echo "  - Add ADR if significant decision was made" >&2
     
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
     fi
 }
 
@@ -1224,7 +1224,7 @@ action_review() {
     fi
     
     # Check constitution alignment if it exists
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
     if [[ -f "$constitution_file" ]]; then
         echo "" >&2
         echo "📜 Checking constitution alignment..." >&2
@@ -1233,7 +1233,7 @@ action_review() {
     fi
     
     # Check for ADRs
-    local adr_mem_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_mem_dir="$SDD_ROOT/.adlc/memory/adr"
     if [[ -d "$adr_mem_dir" ]]; then
         echo "" >&2
         echo "📋 ADR directory found: $adr_mem_dir" >&2
@@ -1244,11 +1244,11 @@ action_review() {
     
     if $JSON_MODE; then
         if [[ ${#issues[@]} -eq 0 ]]; then
-            echo "{\"status\":\"success\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
         else
             # Format issues as JSON array
             issues_json=$(printf '%s\n' "${issues[@]}" | jq -R . | jq -s .)
-            echo "{\"status\":\"warning\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
+            echo "{\"status\":\"warning\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
         fi
     fi
 }
@@ -1261,10 +1261,10 @@ action_analyze() {
     # Auto-migrate before analysis
 
 
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
 
     local ad_exists=false
     local adr_exists=false
@@ -1332,16 +1332,16 @@ action_analyze() {
             feature_adrs_json=$(printf '%s\n' "${feature_adrs[@]}" | jq -R . | jq -s .)
         fi
 
-        echo "{\"status\":\"success\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Plan DAG (Phase 1 of implement - generate execution plan)
 action_plan_dag() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
 
     echo "📐 DAG Planning Phase" >&2
     echo "" >&2
@@ -1358,7 +1358,7 @@ action_plan_dag() {
     fi
 
     # Ensure directories exist
-    mkdir -p "$REPO_ROOT/.adlc/architect"
+    mkdir -p "$SDD_ROOT/.adlc/architect"
     mkdir -p "$views_dir"
 
     # Extract unique sub-systems from ADR files
@@ -1432,14 +1432,14 @@ action_plan_dag() {
         done
         subsystems_json+="]"
 
-        echo "{\"status\":\"success\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Execute DAG (Phase 2 of implement - generate views based on state)
 action_execute_dag() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
     
     echo "🔧 DAG Execution Phase" >&2
     echo "" >&2
@@ -1470,19 +1470,19 @@ action_execute_dag() {
         if [[ -f "$state_file" ]]; then
             local state_content
             state_content=$(cat "$state_file")
-            echo "{\"status\":\"success\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
         else
-            echo "{\"status\":\"error\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
+            echo "{\"status\":\"error\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
         fi
     fi
 }
 
 # Action: Summarize (Phase 3 of implement - aggregate views into AD.md)
 action_summarize() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     
     echo "📝 Summarization Phase" >&2
     echo "" >&2
@@ -1536,14 +1536,14 @@ action_summarize() {
         done < <(find "$views_dir" -name "*.md" -type f 2>/dev/null)
         views_json+="]"
         
-        echo "{\"status\":\"success\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
     fi
 }
 
 # Action: Validate (READ-ONLY architecture validation for plan alignment)
 action_validate() {
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     echo "🔍 Architecture Validation Mode (READ-ONLY)" >&2
     echo ""
@@ -1558,7 +1558,7 @@ action_validate() {
         echo "⏭️  Architecture not found: $adr_dir" >&2
         echo "     Skipping validation gracefully" >&2
         if $JSON_MODE; then
-            echo "{\"status\":\"skipped\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
+            echo "{\"status\":\"skipped\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
         fi
         exit 0
     fi
@@ -1574,7 +1574,7 @@ action_validate() {
     echo "  4. Report findings (READ-ONLY, no modifications)" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 

--- a/skills/architect/architect-implement/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-implement/scripts/powershell/setup-architect.ps1
@@ -105,6 +105,35 @@ function Seed-Templates {
     }
 }
 
+
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+function Resolve-SddDocsLocation {
+    param([string]$ProjectRoot)
+    $loc = $env:SDD_DOCS_LOCATION
+    if ($loc) { return $loc }
+    $optionsFile = Join-Path $ProjectRoot ".adlc\init-options.json"
+    if (Test-Path $optionsFile) {
+        try {
+            $options = Get-Content $optionsFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            if ($options.sdd_docs_location) { return $options.sdd_docs_location }
+        } catch { }
+    }
+    return ""
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+function Get-SddProjectSubfolderName {
+    param([string]$ProjectRoot)
+    try {
+        $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+        if ($commonDir) {
+            return (Split-Path (Resolve-Path (Join-Path $commonDir "..")).Path -Leaf)
+        }
+    } catch { }
+    return (Split-Path $ProjectRoot -Leaf)
+}
+
 # Detect tech stack from codebase
 function Get-TechStack {
     Write-Host "Scanning codebase for technology stack..." -ForegroundColor Cyan
@@ -520,7 +549,7 @@ function New-ArchitectureDiagrams {
 function Invoke-Specify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "📐 Setting up for interactive ADR creation..." -ForegroundColor Cyan
@@ -537,7 +566,7 @@ function Invoke-Specify {
     }
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -587,7 +616,7 @@ function Invoke-Specify {
     Write-Host "After completion, run '/architect.implement' to generate full AD.md"
     
     if ($Json) {
-        @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
     }
 }
 
@@ -595,7 +624,7 @@ function Invoke-Specify {
 function Invoke-Clarify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
         Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
@@ -617,7 +646,7 @@ function Invoke-Clarify {
     Write-Host "  4. Flag any inconsistencies or gaps"
     
     if ($Json) {
-        @{status="success"; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -625,8 +654,8 @@ function Invoke-Clarify {
 function Invoke-Implement {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $adFile = Join-Path $repoRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
@@ -665,21 +694,21 @@ function Invoke-Implement {
     Write-Host "  7. Clean up drafts if all ADRs are Accepted"
     
     if ($Json) {
-        @{status="success"; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
 # Initialize action (brownfield - reverse-engineer from codebase, ADRs only)
 function Invoke-Init {
-    param($repoRoot, $contextArgs)
+    param($repoRoot, $sddRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "🔍 Initializing brownfield architecture discovery..." -ForegroundColor Cyan
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -770,7 +799,7 @@ function Invoke-Init {
     
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="init"
             adr_dir=$adrDir
             tech_stack=$techStack
@@ -812,7 +841,7 @@ function Invoke-Map {
     # Output structured data for AI agent to populate AD.md Section C
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="map"
             tech_stack=$techStack
             directory_structure=$dirStructure
@@ -866,7 +895,7 @@ function Invoke-Update {
     Write-Host "  - Add ADR if significant decision was made"
     
     if ($Json) {
-        @{status="success"; action="update"; file=$architectureFile} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="update"; file=$architectureFile} | ConvertTo-Json
     }
 }
 
@@ -933,10 +962,10 @@ function Invoke-Review {
     }
     
     # Check constitution alignment (new path: memory/constitution.md)
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     if (-not (Test-Path $constitutionFile)) {
         # Fallback to legacy path
-        $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+        $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     }
     if (Test-Path $constitutionFile) {
         Write-Host ""
@@ -947,9 +976,9 @@ function Invoke-Review {
     
     if ($Json) {
         if ($issues.Count -eq 0) {
-            @{status="success"; action="review"; issues=@()} | ConvertTo-Json
+            @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=@()} | ConvertTo-Json
         } else {
-            @{status="warning"; action="review"; issues=$issues} | ConvertTo-Json
+            @{status="warning"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=$issues} | ConvertTo-Json
         }
     }
 }
@@ -958,15 +987,16 @@ function Invoke-Review {
 function Invoke-Analyze {
     param(
         [string]$repoRoot,
+        [string]$sddRoot,
         [string[]]$contextArgs
     )
     
     Write-Host "🔍 Architecture Analysis Mode" -ForegroundColor Cyan
     Write-Host ""
     
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     
     $adExists = Test-Path $adFile
     $adrExists = Test-Path $adrDir
@@ -1016,7 +1046,7 @@ function Invoke-Analyze {
     
     if ($Json) {
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "analyze"
             ad_file = $adFile
             ad_exists = $adExists
@@ -1035,7 +1065,7 @@ function Invoke-Analyze {
 function Invoke-Validate {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     Write-Host "🔍 Architecture Validation Mode (READ-ONLY)" -ForegroundColor Cyan
     Write-Host ""
@@ -1045,7 +1075,7 @@ function Invoke-Validate {
         Write-Host "⏭️  Architecture not found: $adrDir" -ForegroundColor Yellow
         Write-Host "     Skipping validation gracefully" -ForegroundColor Gray
         if ($Json) {
-            @{status="skipped"; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
+            @{status="skipped"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
         }
         exit 0
     }
@@ -1063,7 +1093,7 @@ function Invoke-Validate {
     Write-Host "  4. Report findings (READ-ONLY, no modifications)"
     
     if ($Json) {
-        @{status="success"; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -1071,9 +1101,9 @@ function Invoke-Validate {
 function Invoke-PlanDag {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "📐 DAG Planning Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1085,7 +1115,7 @@ function Invoke-PlanDag {
     }
     
     # Ensure directories exist
-    $architectDir = Join-Path $repoRoot ".adlc\architect"
+    $architectDir = Join-Path $sddRoot ".adlc\architect"
     if (-not (Test-Path $architectDir)) {
         New-Item -ItemType Directory -Path $architectDir -Force | Out-Null
     }
@@ -1136,7 +1166,7 @@ function Invoke-PlanDag {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "plan-dag"
             adr_dir = $adrDir
             state_file = $stateFile
@@ -1152,8 +1182,8 @@ function Invoke-PlanDag {
 function Invoke-ExecuteDag {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "🔧 DAG Execution Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1183,7 +1213,7 @@ function Invoke-ExecuteDag {
     if ($Json) {
         $stateContent = Get-Content $stateFile -Raw | ConvertFrom-Json
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "execute-dag"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1196,10 +1226,10 @@ function Invoke-ExecuteDag {
 function Invoke-Summarize {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
     
     Write-Host "📝 Summarization Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1244,7 +1274,7 @@ function Invoke-Summarize {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "summarize"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1261,15 +1291,23 @@ try {
     $repoRoot = Get-RepositoryRoot
     Seed-Templates -RepoRoot $repoRoot
 
+    # Resolve external SDD docs location
+    $sddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $repoRoot
+    $sddRoot = if ($sddDocsLocation) {
+        Join-Path $sddDocsLocation (Get-SddProjectSubfolderName -ProjectRoot $repoRoot)
+    } else {
+        $repoRoot
+    }
+
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
     
     # Architecture files (new structure: AD.md at root, ADRs in memory/)
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $templateFile = Join-Path $repoRoot ".adlc\templates\architecture-template.md"
     $adTemplateFile = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
@@ -1289,40 +1327,40 @@ try {
     # Execute action
     switch ($Action) {
         'specify' {
-            Invoke-Specify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Specify -repoRoot $sddRoot -contextArgs $Context
         }
         'clarify' {
-            Invoke-Clarify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Clarify -repoRoot $sddRoot -contextArgs $Context
         }
         'init' {
-            Invoke-Init -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Init -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'map' {
             Invoke-Map -repoRoot $repoRoot
         }
         'implement' {
-            Invoke-Implement -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Implement -repoRoot $sddRoot -contextArgs $Context
         }
         'analyze' {
-            Invoke-Analyze -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Analyze -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'validate' {
-            Invoke-Validate -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Validate -repoRoot $sddRoot -contextArgs $Context
         }
         'plan-dag' {
-            Invoke-PlanDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-PlanDag -repoRoot $sddRoot -contextArgs $Context
         }
         'execute-dag' {
-            Invoke-ExecuteDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-ExecuteDag -repoRoot $sddRoot -contextArgs $Context
         }
         'summarize' {
-            Invoke-Summarize -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Summarize -repoRoot $sddRoot -contextArgs $Context
         }
         'update' {
-            Invoke-Update -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Update -repoRoot $sddRoot -architectureFile $adFile
         }
         'review' {
-            Invoke-Review -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Review -repoRoot $sddRoot -architectureFile $adFile
         }
         default {
             Write-Error "Unknown action: $Action`nUse -Help for usage information"

--- a/skills/architect/architect-init/scripts/bash/common.sh
+++ b/skills/architect/architect-init/scripts/bash/common.sh
@@ -47,11 +47,53 @@ _seed_templates() {
     done
 }
 
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+# Uses the worktree root base name when inside a git worktree, otherwise the repo root base name.
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 # Emulates the get_feature_paths function from the Spec Kit common.sh.
 # The architect setup script evals this output to obtain REPO_ROOT.
 get_feature_paths() {
     local repo_root
     repo_root="$(_get_project_root)"
     _seed_templates "$repo_root"
+    local sdd_docs_location
+    sdd_docs_location=$(resolve_sdd_docs_location "$repo_root")
+    local sdd_root
+    if [[ -n "$sdd_docs_location" ]]; then
+        sdd_root="${sdd_docs_location}/$(sdd_project_subfolder_name "$repo_root")"
+    else
+        sdd_root="$repo_root"
+    fi
     echo "REPO_ROOT=\"$repo_root\""
+    echo "SDD_DOCS_LOCATION=\"$sdd_docs_location\""
+    echo "SDD_ROOT=\"$sdd_root\""
 }

--- a/skills/architect/architect-init/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-init/scripts/bash/setup-architect.sh
@@ -123,7 +123,7 @@ done
 
 # Default action if not specified
 if [[ -z "$ACTION" ]]; then
-    if [[ -f "$REPO_ROOT/AD.md" ]]; then
+    if [[ -f "$SDD_ROOT/AD.md" ]]; then
         ACTION="update"
     else
         ACTION="init"
@@ -131,11 +131,11 @@ if [[ -z "$ACTION" ]]; then
 fi
 
 # Ensure directories exist
-mkdir -p "$REPO_ROOT/.adlc/memory"
-mkdir -p "$REPO_ROOT/.adlc/drafts"
+mkdir -p "$SDD_ROOT/.adlc/memory"
+mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 # Architecture files (ADR Lifecycle)
-AD_FILE="$REPO_ROOT/AD.md"
+AD_FILE="$SDD_ROOT/AD.md"
 TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/architecture-template.md"
 AD_TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/AD-template.md"
 
@@ -599,7 +599,7 @@ parse_fm_title() {
 # Generate adr.md index from individual ADR files
 generate_adr_index() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
     local index_file="$adr_dir/adr.md"
 
     if [[ ! -d "$adr_dir" ]]; then
@@ -655,7 +655,7 @@ generate_adr_index() {
 get_adr_by_id() {
     local adr_id="$1"
     local scope="${2:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     # Normalize ID
     local numeric_id
@@ -675,7 +675,7 @@ get_adr_by_id() {
 # List all ADR IDs
 list_adrs() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | sed -E 's/.*ADR-([0-9]+)\.md/\1/' | sort -n
@@ -685,7 +685,7 @@ list_adrs() {
 # Get ADR count
 get_adr_count() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | wc -l
@@ -699,7 +699,7 @@ write_adr() {
     local adr_id="$1"
     local adr_content="$2"
     local scope="${3:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     mkdir -p "$adr_dir"
 
@@ -720,8 +720,8 @@ move_adr() {
     local from_scope="${2:-drafts}"
     local to_scope="${3:-memory}"
 
-    local from_dir="$REPO_ROOT/.adlc/$from_scope/adr"
-    local to_dir="$REPO_ROOT/.adlc/$to_scope/adr"
+    local from_dir="$SDD_ROOT/.adlc/$from_scope/adr"
+    local to_dir="$SDD_ROOT/.adlc/$to_scope/adr"
 
     local numeric_id
     numeric_id=$(echo "$adr_id" | sed -E 's/[^0-9]//g')
@@ -811,14 +811,14 @@ $diagram_code
 
 # Action: Specify (greenfield - interactive PRD exploration to create ADRs)
 action_specify() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "📐 Setting up for interactive ADR creation..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Show decomposition status
@@ -869,7 +869,7 @@ action_specify() {
     echo "After completion, run '/architect.implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
     fi
 }
 
@@ -879,10 +879,10 @@ action_clarify() {
 
 
     # Check drafts first (primary working location), fall back to memory if drafts is empty
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     local active_dir="$adr_dir"
     local active_dir="$adr_dir"
@@ -924,14 +924,14 @@ action_clarify() {
     echo "  5. Flag any inconsistencies or gaps" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Implement (generate full AD.md from ADRs)
 action_implement() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local ad_file="$REPO_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local ad_file="$SDD_ROOT/AD.md"
     local ad_template="$REPO_ROOT/.adlc/templates/AD-template.md"
     
     # Auto-migrate before checking
@@ -974,20 +974,20 @@ action_implement() {
     echo "  8. Clean up drafts if all ADRs are Accepted" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Initialize (brownfield - reverse-engineer from codebase, ADRs only)
 action_init() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "🔍 Initializing brownfield architecture discovery..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Scan existing docs for deduplication
@@ -1070,7 +1070,7 @@ action_init() {
     echo "      After clarification, run /architect.implement to generate AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
     fi
 }
 
@@ -1100,7 +1100,7 @@ action_map() {
     
     # Output structured data for AI agent to populate AD.md
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
     else
         echo "" >&2
         echo "📋 Mapping complete. Use this information to populate AD.md:" >&2
@@ -1158,7 +1158,7 @@ action_update() {
     echo "  - Add ADR if significant decision was made" >&2
     
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
     fi
 }
 
@@ -1224,7 +1224,7 @@ action_review() {
     fi
     
     # Check constitution alignment if it exists
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
     if [[ -f "$constitution_file" ]]; then
         echo "" >&2
         echo "📜 Checking constitution alignment..." >&2
@@ -1233,7 +1233,7 @@ action_review() {
     fi
     
     # Check for ADRs
-    local adr_mem_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_mem_dir="$SDD_ROOT/.adlc/memory/adr"
     if [[ -d "$adr_mem_dir" ]]; then
         echo "" >&2
         echo "📋 ADR directory found: $adr_mem_dir" >&2
@@ -1244,11 +1244,11 @@ action_review() {
     
     if $JSON_MODE; then
         if [[ ${#issues[@]} -eq 0 ]]; then
-            echo "{\"status\":\"success\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
         else
             # Format issues as JSON array
             issues_json=$(printf '%s\n' "${issues[@]}" | jq -R . | jq -s .)
-            echo "{\"status\":\"warning\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
+            echo "{\"status\":\"warning\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
         fi
     fi
 }
@@ -1261,10 +1261,10 @@ action_analyze() {
     # Auto-migrate before analysis
 
 
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
 
     local ad_exists=false
     local adr_exists=false
@@ -1332,16 +1332,16 @@ action_analyze() {
             feature_adrs_json=$(printf '%s\n' "${feature_adrs[@]}" | jq -R . | jq -s .)
         fi
 
-        echo "{\"status\":\"success\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Plan DAG (Phase 1 of implement - generate execution plan)
 action_plan_dag() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
 
     echo "📐 DAG Planning Phase" >&2
     echo "" >&2
@@ -1358,7 +1358,7 @@ action_plan_dag() {
     fi
 
     # Ensure directories exist
-    mkdir -p "$REPO_ROOT/.adlc/architect"
+    mkdir -p "$SDD_ROOT/.adlc/architect"
     mkdir -p "$views_dir"
 
     # Extract unique sub-systems from ADR files
@@ -1432,14 +1432,14 @@ action_plan_dag() {
         done
         subsystems_json+="]"
 
-        echo "{\"status\":\"success\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Execute DAG (Phase 2 of implement - generate views based on state)
 action_execute_dag() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
     
     echo "🔧 DAG Execution Phase" >&2
     echo "" >&2
@@ -1470,19 +1470,19 @@ action_execute_dag() {
         if [[ -f "$state_file" ]]; then
             local state_content
             state_content=$(cat "$state_file")
-            echo "{\"status\":\"success\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
         else
-            echo "{\"status\":\"error\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
+            echo "{\"status\":\"error\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
         fi
     fi
 }
 
 # Action: Summarize (Phase 3 of implement - aggregate views into AD.md)
 action_summarize() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     
     echo "📝 Summarization Phase" >&2
     echo "" >&2
@@ -1536,14 +1536,14 @@ action_summarize() {
         done < <(find "$views_dir" -name "*.md" -type f 2>/dev/null)
         views_json+="]"
         
-        echo "{\"status\":\"success\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
     fi
 }
 
 # Action: Validate (READ-ONLY architecture validation for plan alignment)
 action_validate() {
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     echo "🔍 Architecture Validation Mode (READ-ONLY)" >&2
     echo ""
@@ -1558,7 +1558,7 @@ action_validate() {
         echo "⏭️  Architecture not found: $adr_dir" >&2
         echo "     Skipping validation gracefully" >&2
         if $JSON_MODE; then
-            echo "{\"status\":\"skipped\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
+            echo "{\"status\":\"skipped\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
         fi
         exit 0
     fi
@@ -1574,7 +1574,7 @@ action_validate() {
     echo "  4. Report findings (READ-ONLY, no modifications)" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 

--- a/skills/architect/architect-init/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-init/scripts/powershell/setup-architect.ps1
@@ -105,6 +105,35 @@ function Seed-Templates {
     }
 }
 
+
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+function Resolve-SddDocsLocation {
+    param([string]$ProjectRoot)
+    $loc = $env:SDD_DOCS_LOCATION
+    if ($loc) { return $loc }
+    $optionsFile = Join-Path $ProjectRoot ".adlc\init-options.json"
+    if (Test-Path $optionsFile) {
+        try {
+            $options = Get-Content $optionsFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            if ($options.sdd_docs_location) { return $options.sdd_docs_location }
+        } catch { }
+    }
+    return ""
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+function Get-SddProjectSubfolderName {
+    param([string]$ProjectRoot)
+    try {
+        $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+        if ($commonDir) {
+            return (Split-Path (Resolve-Path (Join-Path $commonDir "..")).Path -Leaf)
+        }
+    } catch { }
+    return (Split-Path $ProjectRoot -Leaf)
+}
+
 # Detect tech stack from codebase
 function Get-TechStack {
     Write-Host "Scanning codebase for technology stack..." -ForegroundColor Cyan
@@ -520,7 +549,7 @@ function New-ArchitectureDiagrams {
 function Invoke-Specify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "📐 Setting up for interactive ADR creation..." -ForegroundColor Cyan
@@ -537,7 +566,7 @@ function Invoke-Specify {
     }
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -587,7 +616,7 @@ function Invoke-Specify {
     Write-Host "After completion, run '/architect.implement' to generate full AD.md"
     
     if ($Json) {
-        @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
     }
 }
 
@@ -595,7 +624,7 @@ function Invoke-Specify {
 function Invoke-Clarify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
         Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
@@ -617,7 +646,7 @@ function Invoke-Clarify {
     Write-Host "  4. Flag any inconsistencies or gaps"
     
     if ($Json) {
-        @{status="success"; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -625,8 +654,8 @@ function Invoke-Clarify {
 function Invoke-Implement {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $adFile = Join-Path $repoRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
@@ -665,21 +694,21 @@ function Invoke-Implement {
     Write-Host "  7. Clean up drafts if all ADRs are Accepted"
     
     if ($Json) {
-        @{status="success"; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
 # Initialize action (brownfield - reverse-engineer from codebase, ADRs only)
 function Invoke-Init {
-    param($repoRoot, $contextArgs)
+    param($repoRoot, $sddRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "🔍 Initializing brownfield architecture discovery..." -ForegroundColor Cyan
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -770,7 +799,7 @@ function Invoke-Init {
     
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="init"
             adr_dir=$adrDir
             tech_stack=$techStack
@@ -812,7 +841,7 @@ function Invoke-Map {
     # Output structured data for AI agent to populate AD.md Section C
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="map"
             tech_stack=$techStack
             directory_structure=$dirStructure
@@ -866,7 +895,7 @@ function Invoke-Update {
     Write-Host "  - Add ADR if significant decision was made"
     
     if ($Json) {
-        @{status="success"; action="update"; file=$architectureFile} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="update"; file=$architectureFile} | ConvertTo-Json
     }
 }
 
@@ -933,10 +962,10 @@ function Invoke-Review {
     }
     
     # Check constitution alignment (new path: memory/constitution.md)
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     if (-not (Test-Path $constitutionFile)) {
         # Fallback to legacy path
-        $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+        $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     }
     if (Test-Path $constitutionFile) {
         Write-Host ""
@@ -947,9 +976,9 @@ function Invoke-Review {
     
     if ($Json) {
         if ($issues.Count -eq 0) {
-            @{status="success"; action="review"; issues=@()} | ConvertTo-Json
+            @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=@()} | ConvertTo-Json
         } else {
-            @{status="warning"; action="review"; issues=$issues} | ConvertTo-Json
+            @{status="warning"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=$issues} | ConvertTo-Json
         }
     }
 }
@@ -958,15 +987,16 @@ function Invoke-Review {
 function Invoke-Analyze {
     param(
         [string]$repoRoot,
+        [string]$sddRoot,
         [string[]]$contextArgs
     )
     
     Write-Host "🔍 Architecture Analysis Mode" -ForegroundColor Cyan
     Write-Host ""
     
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     
     $adExists = Test-Path $adFile
     $adrExists = Test-Path $adrDir
@@ -1016,7 +1046,7 @@ function Invoke-Analyze {
     
     if ($Json) {
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "analyze"
             ad_file = $adFile
             ad_exists = $adExists
@@ -1035,7 +1065,7 @@ function Invoke-Analyze {
 function Invoke-Validate {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     Write-Host "🔍 Architecture Validation Mode (READ-ONLY)" -ForegroundColor Cyan
     Write-Host ""
@@ -1045,7 +1075,7 @@ function Invoke-Validate {
         Write-Host "⏭️  Architecture not found: $adrDir" -ForegroundColor Yellow
         Write-Host "     Skipping validation gracefully" -ForegroundColor Gray
         if ($Json) {
-            @{status="skipped"; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
+            @{status="skipped"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
         }
         exit 0
     }
@@ -1063,7 +1093,7 @@ function Invoke-Validate {
     Write-Host "  4. Report findings (READ-ONLY, no modifications)"
     
     if ($Json) {
-        @{status="success"; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -1071,9 +1101,9 @@ function Invoke-Validate {
 function Invoke-PlanDag {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "📐 DAG Planning Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1085,7 +1115,7 @@ function Invoke-PlanDag {
     }
     
     # Ensure directories exist
-    $architectDir = Join-Path $repoRoot ".adlc\architect"
+    $architectDir = Join-Path $sddRoot ".adlc\architect"
     if (-not (Test-Path $architectDir)) {
         New-Item -ItemType Directory -Path $architectDir -Force | Out-Null
     }
@@ -1136,7 +1166,7 @@ function Invoke-PlanDag {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "plan-dag"
             adr_dir = $adrDir
             state_file = $stateFile
@@ -1152,8 +1182,8 @@ function Invoke-PlanDag {
 function Invoke-ExecuteDag {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "🔧 DAG Execution Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1183,7 +1213,7 @@ function Invoke-ExecuteDag {
     if ($Json) {
         $stateContent = Get-Content $stateFile -Raw | ConvertFrom-Json
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "execute-dag"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1196,10 +1226,10 @@ function Invoke-ExecuteDag {
 function Invoke-Summarize {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
     
     Write-Host "📝 Summarization Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1244,7 +1274,7 @@ function Invoke-Summarize {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "summarize"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1261,15 +1291,23 @@ try {
     $repoRoot = Get-RepositoryRoot
     Seed-Templates -RepoRoot $repoRoot
 
+    # Resolve external SDD docs location
+    $sddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $repoRoot
+    $sddRoot = if ($sddDocsLocation) {
+        Join-Path $sddDocsLocation (Get-SddProjectSubfolderName -ProjectRoot $repoRoot)
+    } else {
+        $repoRoot
+    }
+
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
     
     # Architecture files (new structure: AD.md at root, ADRs in memory/)
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $templateFile = Join-Path $repoRoot ".adlc\templates\architecture-template.md"
     $adTemplateFile = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
@@ -1289,40 +1327,40 @@ try {
     # Execute action
     switch ($Action) {
         'specify' {
-            Invoke-Specify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Specify -repoRoot $sddRoot -contextArgs $Context
         }
         'clarify' {
-            Invoke-Clarify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Clarify -repoRoot $sddRoot -contextArgs $Context
         }
         'init' {
-            Invoke-Init -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Init -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'map' {
             Invoke-Map -repoRoot $repoRoot
         }
         'implement' {
-            Invoke-Implement -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Implement -repoRoot $sddRoot -contextArgs $Context
         }
         'analyze' {
-            Invoke-Analyze -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Analyze -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'validate' {
-            Invoke-Validate -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Validate -repoRoot $sddRoot -contextArgs $Context
         }
         'plan-dag' {
-            Invoke-PlanDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-PlanDag -repoRoot $sddRoot -contextArgs $Context
         }
         'execute-dag' {
-            Invoke-ExecuteDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-ExecuteDag -repoRoot $sddRoot -contextArgs $Context
         }
         'summarize' {
-            Invoke-Summarize -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Summarize -repoRoot $sddRoot -contextArgs $Context
         }
         'update' {
-            Invoke-Update -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Update -repoRoot $sddRoot -architectureFile $adFile
         }
         'review' {
-            Invoke-Review -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Review -repoRoot $sddRoot -architectureFile $adFile
         }
         default {
             Write-Error "Unknown action: $Action`nUse -Help for usage information"

--- a/skills/architect/architect-specify/scripts/bash/common.sh
+++ b/skills/architect/architect-specify/scripts/bash/common.sh
@@ -47,11 +47,53 @@ _seed_templates() {
     done
 }
 
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+# Uses the worktree root base name when inside a git worktree, otherwise the repo root base name.
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 # Emulates the get_feature_paths function from the Spec Kit common.sh.
 # The architect setup script evals this output to obtain REPO_ROOT.
 get_feature_paths() {
     local repo_root
     repo_root="$(_get_project_root)"
     _seed_templates "$repo_root"
+    local sdd_docs_location
+    sdd_docs_location=$(resolve_sdd_docs_location "$repo_root")
+    local sdd_root
+    if [[ -n "$sdd_docs_location" ]]; then
+        sdd_root="${sdd_docs_location}/$(sdd_project_subfolder_name "$repo_root")"
+    else
+        sdd_root="$repo_root"
+    fi
     echo "REPO_ROOT=\"$repo_root\""
+    echo "SDD_DOCS_LOCATION=\"$sdd_docs_location\""
+    echo "SDD_ROOT=\"$sdd_root\""
 }

--- a/skills/architect/architect-specify/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-specify/scripts/bash/setup-architect.sh
@@ -123,7 +123,7 @@ done
 
 # Default action if not specified
 if [[ -z "$ACTION" ]]; then
-    if [[ -f "$REPO_ROOT/AD.md" ]]; then
+    if [[ -f "$SDD_ROOT/AD.md" ]]; then
         ACTION="update"
     else
         ACTION="init"
@@ -131,11 +131,11 @@ if [[ -z "$ACTION" ]]; then
 fi
 
 # Ensure directories exist
-mkdir -p "$REPO_ROOT/.adlc/memory"
-mkdir -p "$REPO_ROOT/.adlc/drafts"
+mkdir -p "$SDD_ROOT/.adlc/memory"
+mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 # Architecture files (ADR Lifecycle)
-AD_FILE="$REPO_ROOT/AD.md"
+AD_FILE="$SDD_ROOT/AD.md"
 TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/architecture-template.md"
 AD_TEMPLATE_FILE="$REPO_ROOT/.adlc/templates/AD-template.md"
 
@@ -599,7 +599,7 @@ parse_fm_title() {
 # Generate adr.md index from individual ADR files
 generate_adr_index() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
     local index_file="$adr_dir/adr.md"
 
     if [[ ! -d "$adr_dir" ]]; then
@@ -655,7 +655,7 @@ generate_adr_index() {
 get_adr_by_id() {
     local adr_id="$1"
     local scope="${2:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     # Normalize ID
     local numeric_id
@@ -675,7 +675,7 @@ get_adr_by_id() {
 # List all ADR IDs
 list_adrs() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | sed -E 's/.*ADR-([0-9]+)\.md/\1/' | sort -n
@@ -685,7 +685,7 @@ list_adrs() {
 # Get ADR count
 get_adr_count() {
     local scope="${1:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     if [[ -d "$adr_dir" ]]; then
         ls -1 "$adr_dir"/ADR-*.md 2>/dev/null | wc -l
@@ -699,7 +699,7 @@ write_adr() {
     local adr_id="$1"
     local adr_content="$2"
     local scope="${3:-drafts}"
-    local adr_dir="$REPO_ROOT/.adlc/$scope/adr"
+    local adr_dir="$SDD_ROOT/.adlc/$scope/adr"
 
     mkdir -p "$adr_dir"
 
@@ -720,8 +720,8 @@ move_adr() {
     local from_scope="${2:-drafts}"
     local to_scope="${3:-memory}"
 
-    local from_dir="$REPO_ROOT/.adlc/$from_scope/adr"
-    local to_dir="$REPO_ROOT/.adlc/$to_scope/adr"
+    local from_dir="$SDD_ROOT/.adlc/$from_scope/adr"
+    local to_dir="$SDD_ROOT/.adlc/$to_scope/adr"
 
     local numeric_id
     numeric_id=$(echo "$adr_id" | sed -E 's/[^0-9]//g')
@@ -811,14 +811,14 @@ $diagram_code
 
 # Action: Specify (greenfield - interactive PRD exploration to create ADRs)
 action_specify() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "📐 Setting up for interactive ADR creation..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Show decomposition status
@@ -869,7 +869,7 @@ action_specify() {
     echo "After completion, run '/architect.implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
     fi
 }
 
@@ -879,10 +879,10 @@ action_clarify() {
 
 
     # Check drafts first (primary working location), fall back to memory if drafts is empty
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local fallback_adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local fallback_adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     local active_dir="$adr_dir"
     local active_dir="$adr_dir"
@@ -924,14 +924,14 @@ action_clarify() {
     echo "  5. Flag any inconsistencies or gaps" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"clarify\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"format\":\"$format\",\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Implement (generate full AD.md from ADRs)
 action_implement() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local ad_file="$REPO_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local ad_file="$SDD_ROOT/AD.md"
     local ad_template="$REPO_ROOT/.adlc/templates/AD-template.md"
     
     # Auto-migrate before checking
@@ -974,20 +974,20 @@ action_implement() {
     echo "  8. Clean up drafts if all ADRs are Accepted" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"implement\",\"adr_dir\":\"$adr_dir\",\"ad_file\":\"$ad_file\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Initialize (brownfield - reverse-engineer from codebase, ADRs only)
 action_init() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     local adr_template="$REPO_ROOT/.adlc/templates/adr-template.md"
 
     echo "🔍 Initializing brownfield architecture discovery..." >&2
 
     # Ensure drafts directory exists
-    mkdir -p "$REPO_ROOT/.adlc/drafts"
+    mkdir -p "$SDD_ROOT/.adlc/drafts"
 
 
     # Scan existing docs for deduplication
@@ -1070,7 +1070,7 @@ action_init() {
     echo "      After clarification, run /architect.implement to generate AD.md" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
     fi
 }
 
@@ -1100,7 +1100,7 @@ action_map() {
     
     # Output structured data for AI agent to populate AD.md
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"map\",\"tech_stack\":\"$tech_stack\",\"directory_structure\":\"$dir_structure\",\"existing_docs\":\"$existing_docs\"}"
     else
         echo "" >&2
         echo "📋 Mapping complete. Use this information to populate AD.md:" >&2
@@ -1158,7 +1158,7 @@ action_update() {
     echo "  - Add ADR if significant decision was made" >&2
     
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"update\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_dir\"}"
     fi
 }
 
@@ -1224,7 +1224,7 @@ action_review() {
     fi
     
     # Check constitution alignment if it exists
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
     if [[ -f "$constitution_file" ]]; then
         echo "" >&2
         echo "📜 Checking constitution alignment..." >&2
@@ -1233,7 +1233,7 @@ action_review() {
     fi
     
     # Check for ADRs
-    local adr_mem_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_mem_dir="$SDD_ROOT/.adlc/memory/adr"
     if [[ -d "$adr_mem_dir" ]]; then
         echo "" >&2
         echo "📋 ADR directory found: $adr_mem_dir" >&2
@@ -1244,11 +1244,11 @@ action_review() {
     
     if $JSON_MODE; then
         if [[ ${#issues[@]} -eq 0 ]]; then
-            echo "{\"status\":\"success\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":[]}"
         else
             # Format issues as JSON array
             issues_json=$(printf '%s\n' "${issues[@]}" | jq -R . | jq -s .)
-            echo "{\"status\":\"warning\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
+            echo "{\"status\":\"warning\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"review\",\"ad_file\":\"$AD_FILE\",\"adr_dir\":\"$adr_mem_dir\",\"issues\":$issues_json}"
         fi
     fi
 }
@@ -1261,10 +1261,10 @@ action_analyze() {
     # Auto-migrate before analysis
 
 
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local constitution_file="$REPO_ROOT/.adlc/memory/constitution.md"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local constitution_file="$SDD_ROOT/.adlc/memory/constitution.md"
 
     local ad_exists=false
     local adr_exists=false
@@ -1332,16 +1332,16 @@ action_analyze() {
             feature_adrs_json=$(printf '%s\n' "${feature_adrs[@]}" | jq -R . | jq -s .)
         fi
 
-        echo "{\"status\":\"success\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"analyze\",\"ad_file\":\"$ad_file\",\"ad_exists\":$ad_exists,\"adr_dir\":\"$adr_dir\",\"adr_exists\":$adr_exists,\"constitution_file\":\"$constitution_file\",\"constitution_exists\":$constitution_exists,\"feature_ads\":$feature_ads_json,\"feature_adrs\":$feature_adrs_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Plan DAG (Phase 1 of implement - generate execution plan)
 action_plan_dag() {
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
 
     echo "📐 DAG Planning Phase" >&2
     echo "" >&2
@@ -1358,7 +1358,7 @@ action_plan_dag() {
     fi
 
     # Ensure directories exist
-    mkdir -p "$REPO_ROOT/.adlc/architect"
+    mkdir -p "$SDD_ROOT/.adlc/architect"
     mkdir -p "$views_dir"
 
     # Extract unique sub-systems from ADR files
@@ -1432,14 +1432,14 @@ action_plan_dag() {
         done
         subsystems_json+="]"
 
-        echo "{\"status\":\"success\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"plan-dag\",\"adr_dir\":\"$adr_dir\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"adr_count\":$adr_count,\"subsystems\":$subsystems_json,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 
 # Action: Execute DAG (Phase 2 of implement - generate views based on state)
 action_execute_dag() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
     
     echo "🔧 DAG Execution Phase" >&2
     echo "" >&2
@@ -1470,19 +1470,19 @@ action_execute_dag() {
         if [[ -f "$state_file" ]]; then
             local state_content
             state_content=$(cat "$state_file")
-            echo "{\"status\":\"success\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
+            echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"state\":$state_content}"
         else
-            echo "{\"status\":\"error\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
+            echo "{\"status\":\"error\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"execute-dag\",\"error\":\"state_file_not_found\"}"
         fi
     fi
 }
 
 # Action: Summarize (Phase 3 of implement - aggregate views into AD.md)
 action_summarize() {
-    local state_file="$REPO_ROOT/.adlc/architect/state.json"
-    local views_dir="$REPO_ROOT/.adlc/architect/views"
-    local ad_file="$REPO_ROOT/AD.md"
-    local adr_dir="$REPO_ROOT/.adlc/drafts/adr"
+    local state_file="$SDD_ROOT/.adlc/architect/state.json"
+    local views_dir="$SDD_ROOT/.adlc/architect/views"
+    local ad_file="$SDD_ROOT/AD.md"
+    local adr_dir="$SDD_ROOT/.adlc/drafts/adr"
     
     echo "📝 Summarization Phase" >&2
     echo "" >&2
@@ -1536,14 +1536,14 @@ action_summarize() {
         done < <(find "$views_dir" -name "*.md" -type f 2>/dev/null)
         views_json+="]"
         
-        echo "{\"status\":\"success\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"summarize\",\"state_file\":\"$state_file\",\"views_dir\":\"$views_dir\",\"ad_file\":\"$ad_file\",\"adr_dir\":\"$adr_dir\",\"view_count\":$view_count,\"views\":$views_json}"
     fi
 }
 
 # Action: Validate (READ-ONLY architecture validation for plan alignment)
 action_validate() {
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
-    local adr_dir="$REPO_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
+    local adr_dir="$SDD_ROOT/.adlc/memory/adr"
 
     echo "🔍 Architecture Validation Mode (READ-ONLY)" >&2
     echo ""
@@ -1558,7 +1558,7 @@ action_validate() {
         echo "⏭️  Architecture not found: $adr_dir" >&2
         echo "     Skipping validation gracefully" >&2
         if $JSON_MODE; then
-            echo "{\"status\":\"skipped\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
+            echo "{\"status\":\"skipped\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"reason\":\"architecture_not_found\"}"
         fi
         exit 0
     fi
@@ -1574,7 +1574,7 @@ action_validate() {
     echo "  4. Report findings (READ-ONLY, no modifications)" >&2
 
     if $JSON_MODE; then
-        echo "{\"status\":\"success\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
+        echo "{\"status\":\"success\",\"sdd_docs_location\":\"$SDD_DOCS_LOCATION\",\"sdd_root\":\"$SDD_ROOT\",\"action\":\"validate\",\"adr_dir\":\"$adr_dir\",\"adr_count\":$adr_count,\"context\":\"${ARGS[*]}\"}"
     fi
 }
 

--- a/skills/architect/architect-specify/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-specify/scripts/powershell/setup-architect.ps1
@@ -105,6 +105,35 @@ function Seed-Templates {
     }
 }
 
+
+# Resolve external SDD docs location.
+# Priority: SDD_DOCS_LOCATION env var > .adlc/init-options.json > empty (use repo root).
+function Resolve-SddDocsLocation {
+    param([string]$ProjectRoot)
+    $loc = $env:SDD_DOCS_LOCATION
+    if ($loc) { return $loc }
+    $optionsFile = Join-Path $ProjectRoot ".adlc\init-options.json"
+    if (Test-Path $optionsFile) {
+        try {
+            $options = Get-Content $optionsFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            if ($options.sdd_docs_location) { return $options.sdd_docs_location }
+        } catch { }
+    }
+    return ""
+}
+
+# Derive a stable subfolder name for the current project inside SDD_DOCS_LOCATION.
+function Get-SddProjectSubfolderName {
+    param([string]$ProjectRoot)
+    try {
+        $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+        if ($commonDir) {
+            return (Split-Path (Resolve-Path (Join-Path $commonDir "..")).Path -Leaf)
+        }
+    } catch { }
+    return (Split-Path $ProjectRoot -Leaf)
+}
+
 # Detect tech stack from codebase
 function Get-TechStack {
     Write-Host "Scanning codebase for technology stack..." -ForegroundColor Cyan
@@ -520,7 +549,7 @@ function New-ArchitectureDiagrams {
 function Invoke-Specify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "📐 Setting up for interactive ADR creation..." -ForegroundColor Cyan
@@ -537,7 +566,7 @@ function Invoke-Specify {
     }
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -587,7 +616,7 @@ function Invoke-Specify {
     Write-Host "After completion, run '/architect.implement' to generate full AD.md"
     
     if ($Json) {
-        @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
     }
 }
 
@@ -595,7 +624,7 @@ function Invoke-Specify {
 function Invoke-Clarify {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
         Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
@@ -617,7 +646,7 @@ function Invoke-Clarify {
     Write-Host "  4. Flag any inconsistencies or gaps"
     
     if ($Json) {
-        @{status="success"; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="clarify"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -625,8 +654,8 @@ function Invoke-Clarify {
 function Invoke-Implement {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $adFile = Join-Path $repoRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
@@ -665,21 +694,21 @@ function Invoke-Implement {
     Write-Host "  7. Clean up drafts if all ADRs are Accepted"
     
     if ($Json) {
-        @{status="success"; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="implement"; adr_dir=$adrDir; ad_file=$adFile; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
 # Initialize action (brownfield - reverse-engineer from codebase, ADRs only)
 function Invoke-Init {
-    param($repoRoot, $contextArgs)
+    param($repoRoot, $sddRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $adrTemplate = Join-Path $repoRoot ".adlc\templates\adr-template.md"
     
     Write-Host "🔍 Initializing brownfield architecture discovery..." -ForegroundColor Cyan
     
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
@@ -770,7 +799,7 @@ function Invoke-Init {
     
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="init"
             adr_dir=$adrDir
             tech_stack=$techStack
@@ -812,7 +841,7 @@ function Invoke-Map {
     # Output structured data for AI agent to populate AD.md Section C
     if ($Json) {
         @{
-            status="success"
+            status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot
             action="map"
             tech_stack=$techStack
             directory_structure=$dirStructure
@@ -866,7 +895,7 @@ function Invoke-Update {
     Write-Host "  - Add ADR if significant decision was made"
     
     if ($Json) {
-        @{status="success"; action="update"; file=$architectureFile} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="update"; file=$architectureFile} | ConvertTo-Json
     }
 }
 
@@ -933,10 +962,10 @@ function Invoke-Review {
     }
     
     # Check constitution alignment (new path: memory/constitution.md)
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     if (-not (Test-Path $constitutionFile)) {
         # Fallback to legacy path
-        $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+        $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     }
     if (Test-Path $constitutionFile) {
         Write-Host ""
@@ -947,9 +976,9 @@ function Invoke-Review {
     
     if ($Json) {
         if ($issues.Count -eq 0) {
-            @{status="success"; action="review"; issues=@()} | ConvertTo-Json
+            @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=@()} | ConvertTo-Json
         } else {
-            @{status="warning"; action="review"; issues=$issues} | ConvertTo-Json
+            @{status="warning"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="review"; issues=$issues} | ConvertTo-Json
         }
     }
 }
@@ -958,15 +987,16 @@ function Invoke-Review {
 function Invoke-Analyze {
     param(
         [string]$repoRoot,
+        [string]$sddRoot,
         [string[]]$contextArgs
     )
     
     Write-Host "🔍 Architecture Analysis Mode" -ForegroundColor Cyan
     Write-Host ""
     
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
-    $constitutionFile = Join-Path $repoRoot ".adlc\memory\constitution.md"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
+    $constitutionFile = Join-Path $sddRoot ".adlc\memory\constitution.md"
     
     $adExists = Test-Path $adFile
     $adrExists = Test-Path $adrDir
@@ -1016,7 +1046,7 @@ function Invoke-Analyze {
     
     if ($Json) {
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "analyze"
             ad_file = $adFile
             ad_exists = $adExists
@@ -1035,7 +1065,7 @@ function Invoke-Analyze {
 function Invoke-Validate {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     
     Write-Host "🔍 Architecture Validation Mode (READ-ONLY)" -ForegroundColor Cyan
     Write-Host ""
@@ -1045,7 +1075,7 @@ function Invoke-Validate {
         Write-Host "⏭️  Architecture not found: $adrDir" -ForegroundColor Yellow
         Write-Host "     Skipping validation gracefully" -ForegroundColor Gray
         if ($Json) {
-            @{status="skipped"; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
+            @{status="skipped"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; reason="architecture_not_found"} | ConvertTo-Json
         }
         exit 0
     }
@@ -1063,7 +1093,7 @@ function Invoke-Validate {
     Write-Host "  4. Report findings (READ-ONLY, no modifications)"
     
     if ($Json) {
-        @{status="success"; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
+        @{status="success"; sdd_docs_location=$sddDocsLocation; sdd_root=$sddRoot; action="validate"; adr_dir=$adrDir; adr_count=$adrCount; context=($contextArgs -join " ")} | ConvertTo-Json
     }
 }
 
@@ -1071,9 +1101,9 @@ function Invoke-Validate {
 function Invoke-PlanDag {
     param($repoRoot, $contextArgs)
     
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "📐 DAG Planning Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1085,7 +1115,7 @@ function Invoke-PlanDag {
     }
     
     # Ensure directories exist
-    $architectDir = Join-Path $repoRoot ".adlc\architect"
+    $architectDir = Join-Path $sddRoot ".adlc\architect"
     if (-not (Test-Path $architectDir)) {
         New-Item -ItemType Directory -Path $architectDir -Force | Out-Null
     }
@@ -1136,7 +1166,7 @@ function Invoke-PlanDag {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "plan-dag"
             adr_dir = $adrDir
             state_file = $stateFile
@@ -1152,8 +1182,8 @@ function Invoke-PlanDag {
 function Invoke-ExecuteDag {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
     
     Write-Host "🔧 DAG Execution Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1183,7 +1213,7 @@ function Invoke-ExecuteDag {
     if ($Json) {
         $stateContent = Get-Content $stateFile -Raw | ConvertFrom-Json
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "execute-dag"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1196,10 +1226,10 @@ function Invoke-ExecuteDag {
 function Invoke-Summarize {
     param($repoRoot, $contextArgs)
     
-    $stateFile = Join-Path $repoRoot ".adlc\architect\state.json"
-    $viewsDir = Join-Path $repoRoot ".adlc\architect\views"
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\drafts\adr"
+    $stateFile = Join-Path $sddRoot ".adlc\architect\state.json"
+    $viewsDir = Join-Path $sddRoot ".adlc\architect\views"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\drafts\adr"
     
     Write-Host "📝 Summarization Phase" -ForegroundColor Cyan
     Write-Host ""
@@ -1244,7 +1274,7 @@ function Invoke-Summarize {
             }
         }
         @{
-            status = "success"
+            status = "success"; sdd_docs_location = $sddDocsLocation; sdd_root = $sddRoot
             action = "summarize"
             state_file = $stateFile
             views_dir = $viewsDir
@@ -1261,15 +1291,23 @@ try {
     $repoRoot = Get-RepositoryRoot
     Seed-Templates -RepoRoot $repoRoot
 
+    # Resolve external SDD docs location
+    $sddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $repoRoot
+    $sddRoot = if ($sddDocsLocation) {
+        Join-Path $sddDocsLocation (Get-SddProjectSubfolderName -ProjectRoot $repoRoot)
+    } else {
+        $repoRoot
+    }
+
     # Ensure memory directory exists
-    $memoryDir = Join-Path $repoRoot ".adlc\memory"
+    $memoryDir = Join-Path $sddRoot ".adlc\memory"
     if (-not (Test-Path $memoryDir)) {
         New-Item -ItemType Directory -Path $memoryDir -Force | Out-Null
     }
     
     # Architecture files (new structure: AD.md at root, ADRs in memory/)
-    $adFile = Join-Path $repoRoot "AD.md"
-    $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
+    $adFile = Join-Path $sddRoot "AD.md"
+    $adrDir = Join-Path $sddRoot ".adlc\memory\adr"
     $templateFile = Join-Path $repoRoot ".adlc\templates\architecture-template.md"
     $adTemplateFile = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
@@ -1289,40 +1327,40 @@ try {
     # Execute action
     switch ($Action) {
         'specify' {
-            Invoke-Specify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Specify -repoRoot $sddRoot -contextArgs $Context
         }
         'clarify' {
-            Invoke-Clarify -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Clarify -repoRoot $sddRoot -contextArgs $Context
         }
         'init' {
-            Invoke-Init -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Init -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'map' {
             Invoke-Map -repoRoot $repoRoot
         }
         'implement' {
-            Invoke-Implement -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Implement -repoRoot $sddRoot -contextArgs $Context
         }
         'analyze' {
-            Invoke-Analyze -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Analyze -repoRoot $repoRoot -sddRoot $sddRoot -contextArgs $Context
         }
         'validate' {
-            Invoke-Validate -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Validate -repoRoot $sddRoot -contextArgs $Context
         }
         'plan-dag' {
-            Invoke-PlanDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-PlanDag -repoRoot $sddRoot -contextArgs $Context
         }
         'execute-dag' {
-            Invoke-ExecuteDag -repoRoot $repoRoot -contextArgs $Context
+            Invoke-ExecuteDag -repoRoot $sddRoot -contextArgs $Context
         }
         'summarize' {
-            Invoke-Summarize -repoRoot $repoRoot -contextArgs $Context
+            Invoke-Summarize -repoRoot $sddRoot -contextArgs $Context
         }
         'update' {
-            Invoke-Update -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Update -repoRoot $sddRoot -architectureFile $adFile
         }
         'review' {
-            Invoke-Review -repoRoot $repoRoot -architectureFile $adFile
+            Invoke-Review -repoRoot $sddRoot -architectureFile $adFile
         }
         default {
             Write-Error "Unknown action: $Action`nUse -Help for usage information"

--- a/skills/evals/evals-analyze/SKILL.md
+++ b/skills/evals/evals-analyze/SKILL.md
@@ -13,7 +13,7 @@ Provides **cross-functional team elevation** and **closed-loop feedback** follow
 **Output**:
 1. **Trajectory Analysis** - Full multi-turn trace analysis with tool calls and context preservation (EDD Principle V)
 2. **Failure Routing**:
-   - **Specification Failures** (agent logic missing/ambiguous) → Automatically triggers a local call to `levelup-specify` to propose new context rules in `.adlc/drafts/cdr/` to fix agent behavior.
+   - **Specification Failures** (agent logic missing/ambiguous) → Automatically triggers a local call to `levelup-specify` to propose new context rules in `$SDD_ROOT/.adlc/drafts/cdr/` to fix agent behavior.
    - **Generalization Failures** (grader flawed or lacks edge-case coverage) → Appends evaluator backlog items to the project backlog for ongoing monitoring.
 3. **Cross-Functional PR** - Creates a team-ai-directives PR with insights and rule updates (EDD Principle X)
 
@@ -30,7 +30,7 @@ Provides **cross-functional team elevation** and **closed-loop feedback** follow
 
 ## When NOT to use
 
-- **Evals not yet executed**: Run `/evals-validate` first to generate results in `evals/results/`
+- **Evals not yet executed**: Run `/evals-validate` first to generate results in `$SDD_ROOT/evals/results/`
 - **Trivial tasks**: Closed-loop analysis is overhead for simple features
 
 ## Process
@@ -45,7 +45,7 @@ $ARGUMENTS
 ### Execution Steps
 
 #### Phase 1: Load Evaluation Results
-- Reads results JSON from `evals/results/`.
+- Reads results JSON from `$SDD_ROOT/evals/results/`.
 - Extracts failure cases and full multi-turn conversation traces (including tool calls).
 
 #### Phase 2: Failure Classification
@@ -54,17 +54,17 @@ Categorizes each failure trace:
 - **Generalization Failure**: The rule was correct, but the agent made a mistake anyway (hallucinated, missed a constraint, or grader lacked edge-case coverage).
 
 #### Phase 3: Action Routing (Close the Loop)
-- **For Specification Failures**: Automatically triggers local skill `/levelup-specify` with the failure trace as input. This creates new rule/persona/example CDRs in `.adlc/drafts/cdr/` to fix the agent's behavior.
-- **For Generalization Failures**: Appends an evaluator backlog item to `evals/results/evaluator_backlog.md` detailing the needed grader edge-case updates.
+- **For Specification Failures**: Automatically triggers local skill `/levelup-specify` with the failure trace as input. This creates new rule/persona/example CDRs in `$SDD_ROOT/.adlc/drafts/cdr/` to fix the agent's behavior.
+- **For Generalization Failures**: Appends an evaluator backlog item to `$SDD_ROOT/evals/results/evaluator_backlog.md` detailing the needed grader edge-case updates.
 
 #### Phase 4: Cross-Functional Insights & PR
-- Generates a stakeholder-specific report in `evals/results/team_insights.md` (tailored for PMs, domain experts, and AI engineers).
+- Generates a stakeholder-specific report in `$SDD_ROOT/evals/results/team_insights.md` (tailored for PMs, domain experts, and AI engineers).
 - If git remote and gh CLI are available, commits rule/eval changes in `team-ai-directives` and opens a draft PR (uses `levelup-publish` logic under the hood).
 
 ## Verification
 - Trajectory failure traces analyzed and classified
-- Specification failures successfully routed to `/levelup-specify` (proposes CDRs in `.adlc/drafts/cdr/`)
-- Generalization failures written to `evals/results/evaluator_backlog.md`
-- Stakeholder report `evals/results/team_insights.md` generated
+- Specification failures successfully routed to `/levelup-specify` (proposes CDRs in `$SDD_ROOT/.adlc/drafts/cdr/`)
+- Generalization failures written to `$SDD_ROOT/evals/results/evaluator_backlog.md`
+- Stakeholder report `$SDD_ROOT/evals/results/team_insights.md` generated
 - Draft PR created in team-ai-directives (if applicable)
 - Final report summary presented with PR link and backlog details

--- a/skills/evals/evals-analyze/scripts/bash/setup-evals-analyze.sh
+++ b/skills/evals/evals-analyze/scripts/bash/setup-evals-analyze.sh
@@ -33,19 +33,56 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
 
-python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" << 'PY'
+python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION" "$SDD_ROOT" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
   "TEAM_AI_DIRECTIVES": sys.argv[2],
-  "BRANCH": sys.argv[3]
+  "BRANCH": sys.argv[3],
+  "SDD_DOCS_LOCATION": sys.argv[4],
+  "SDD_ROOT": sys.argv[5]
 }))
 PY

--- a/skills/evals/evals-analyze/scripts/powershell/setup-evals-analyze.ps1
+++ b/skills/evals/evals-analyze/scripts/powershell/setup-evals-analyze.ps1
@@ -29,6 +29,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -37,12 +62,23 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
 
 $result = @{
     REPO_ROOT = $ProjectRoot
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+    SDD_ROOT = $SddRoot
 }
 
 $result | ConvertTo-Json -Compress

--- a/skills/evals/evals-clarify/SKILL.md
+++ b/skills/evals/evals-clarify/SKILL.md
@@ -13,9 +13,9 @@ Conducts **axial coding** following **EDD Principles III & IX** to cluster relat
 **Output**:
 1. **Clustered Criteria** - Related patterns grouped into coherent evaluation themes
 2. **Adversarial Examples** - Generated attack scenarios and edge cases for robustness
-3. **Published Goldset** - Accepted criteria in `evals/{system}/goldset.md` with full documentation
+3. **Published Goldset** - Accepted criteria in `$SDD_ROOT/evals/{system}/goldset.md` with full documentation
 4. **Holdout Dataset** - Reserved test set (20%) for unbiased evaluation validation
-5. **JSON Configuration** - Auto-generated `goldset.json` for system consumption
+5. **JSON Configuration** - Auto-generated `$SDD_ROOT/evals/{system}/goldset.json` for system consumption
 6. **Auto-handoff** to `/evals-implement` for grader generation
 
 **Key EDD Principles Applied**:
@@ -57,19 +57,19 @@ $ARGUMENTS
 - Balance pass/fail examples (~50/50 ratio).
 
 #### Phase 3: Holdout Isolation
-- Isolate exactly 20% of examples as a reserved holdout set (saved to `.adlc/memory/evals/holdout.json`).
+- Isolate exactly 20% of examples as a reserved holdout set (saved to `$SDD_ROOT/.adlc/memory/evals/holdout.json`).
 - Ensure holdout set is never used in implementation or training.
 
 #### Phase 4: Publish Goldset
-- Copy accepted drafts to `.adlc/memory/evals/` and update status to `accepted`.
-- Compile published goldset to `evals/{system}/goldset.md` (human-readable) and `evals/{system}/goldset.json` (machine-readable).
+- Copy accepted drafts to `$SDD_ROOT/.adlc/memory/evals/` and update status to `accepted`.
+- Compile published goldset to `$SDD_ROOT/evals/{system}/goldset.md` (human-readable) and `$SDD_ROOT/evals/{system}/goldset.json` (machine-readable).
 
 #### Phase 5: Auto-Handoff
 Trigger `/evals-implement` to generate code.
 
 ## Verification
-- Accepted drafts stored in `.adlc/memory/evals/EVAL-*.md`
-- `evals/{system}/goldset.md` and `goldset.json` exist
-- Holdout set `.adlc/memory/evals/holdout.json` isolated and populated
+- Accepted drafts stored in `$SDD_ROOT/.adlc/memory/evals/EVAL-*.md`
+- `$SDD_ROOT/evals/{system}/goldset.md` and `$SDD_ROOT/evals/{system}/goldset.json` exist
+- Holdout set `$SDD_ROOT/.adlc/memory/evals/holdout.json` isolated and populated
 - All criteria are strictly binary (no confidence scores or Likert scales)
 - Handover summary lists accepted criteria and adversarial counts

--- a/skills/evals/evals-clarify/scripts/bash/setup-evals-clarify.sh
+++ b/skills/evals/evals-clarify/scripts/bash/setup-evals-clarify.sh
@@ -33,19 +33,56 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
 
-python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" << 'PY'
+python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION" "$SDD_ROOT" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
   "TEAM_AI_DIRECTIVES": sys.argv[2],
-  "BRANCH": sys.argv[3]
+  "BRANCH": sys.argv[3],
+  "SDD_DOCS_LOCATION": sys.argv[4],
+  "SDD_ROOT": sys.argv[5]
 }))
 PY

--- a/skills/evals/evals-clarify/scripts/powershell/setup-evals-clarify.ps1
+++ b/skills/evals/evals-clarify/scripts/powershell/setup-evals-clarify.ps1
@@ -29,6 +29,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -37,12 +62,23 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
 
 $result = @{
     REPO_ROOT = $ProjectRoot
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+    SDD_ROOT = $SddRoot
 }
 
 $result | ConvertTo-Json -Compress

--- a/skills/evals/evals-implement/SKILL.md
+++ b/skills/evals/evals-implement/SKILL.md
@@ -12,9 +12,9 @@ Generates the **complete executable evaluation implementation** following **EDD 
 
 **Output**:
 1. **Grader/Metric Implementation** - Python evaluators for each goldset criterion with binary pass/fail
-   - PromptFoo: Python grader functions with JSON output in `evals/{system}/graders/`
+   - PromptFoo: Python grader functions with JSON output in `$SDD_ROOT/evals/{system}/graders/`
    - DeepEval: Custom metric classes inheriting from `BaseMetric`
-2. **Evaluator Unit Tests** - Automated tests (`evals/{system}/tests/test_check_*.py`) that run the goldset pass/fail examples against the generated graders to ensure the evaluator itself is accurate
+2. **Evaluator Unit Tests** - Automated tests (`$SDD_ROOT/evals/{system}/tests/test_check_*.py`) that run the goldset pass/fail examples against the generated graders to ensure the evaluator itself is accurate
 3. **Evaluation Configuration** - Complete config file (`config.js` or `config.py`) with Tier 1 + Tier 2 evaluation structure
 4. **Auto-handoff** to `/evals-validate` to run validation
 
@@ -46,21 +46,21 @@ $ARGUMENTS
 ### Execution Steps
 
 #### Phase 1: Trace-to-Grader Synthesis (Automated Eval Engineering)
-- Reads `evals/{system}/goldset.json`.
+- Reads `$SDD_ROOT/evals/{system}/goldset.json`.
 - Maps rich evidence fields from the goldset criteria into grader logic (Trace-to-Grader Synthesis):
   - Uses `pass_condition` and `fail_condition` as the grader's core rubric.
   - Extracts pass/fail examples to act as raw data anchors and few-shot classification anchors inside the grader logic.
   - Injects `Root Cause Analysis` and `axial_coding` notes as contextual prompt guidelines or regex patterns to catch exact failure manifestations.
-- For PromptFoo: Generates Python grader functions (`evals/{system}/graders/check_*.py`) containing specialized, dynamic LLM-judge templates or regex checks compiled from these goldset inputs.
+- For PromptFoo: Generates Python grader functions (`$SDD_ROOT/evals/{system}/graders/check_*.py`) containing specialized, dynamic LLM-judge templates or regex checks compiled from these goldset inputs.
 - For DeepEval: Generates Custom Metric classes inheriting from `BaseMetric` compiled from these goldset inputs.
 - All graders conform strictly to the binary pass/fail standard (returning only `1.0` or `0.0`, with zero Likert scale leakage).
 
 #### Phase 2: Unit Test Generation
-- Generates matching unit tests (`evals/{system}/tests/test_check_*.py`) for each grader.
+- Generates matching unit tests (`$SDD_ROOT/evals/{system}/tests/test_check_*.py`) for each grader.
 - Unit tests verify the grader correctly identifies the goldset's training pass and fail examples.
 
 #### Phase 2b: Closed-Loop Grader Self-Tuning
-- Executes generated unit tests (`pytest evals/{system}/tests/`) to verify evaluator accuracy.
+- Executes generated unit tests (`pytest $SDD_ROOT/evals/{system}/tests/`) to verify evaluator accuracy.
 - **Grader Calibration Loop**:
   1. Inspects test results to detect any misclassifications (false positives/negatives) on the training cases.
   2. If any test fails, triggers a feedback edit step that parses the failure reasons and automatically adjusts the grader's internal prompt rubric, regex stubs, or score thresholds.
@@ -77,10 +77,10 @@ $ARGUMENTS
 Trigger `/evals-validate` to run validation.
 
 ## Verification
-- `evals/{system}/graders/` contains Python grader scripts for each criterion compiled dynamically from goldset pass/fail examples and root-cause analyses
-- `evals/{system}/tests/` contains matching unit test files
+- `$SDD_ROOT/evals/{system}/graders/` contains Python grader scripts for each criterion compiled dynamically from goldset pass/fail examples and root-cause analyses
+- `$SDD_ROOT/evals/{system}/tests/` contains matching unit test files
 - Framework config (`config.js` or `config.py`) successfully generated
 - Grader calibration self-tuning loop ran and converged to 100% training accuracy within the 3-iteration cap (or raised explicit non-convergence errors)
 - Holdout dataset protection confirmed (validation `holdout.json` remained completely isolated and untouched during tuning)
-- All grader unit tests pass locally (`pytest evals/{system}/tests/`)
+- All grader unit tests pass locally (`pytest $SDD_ROOT/evals/{system}/tests/`)
 - Handover summary lists generated graders, self-tuning iterations, and test results

--- a/skills/evals/evals-implement/scripts/bash/setup-evals-implement.sh
+++ b/skills/evals/evals-implement/scripts/bash/setup-evals-implement.sh
@@ -33,19 +33,56 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
 
-python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" << 'PY'
+python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION" "$SDD_ROOT" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
   "TEAM_AI_DIRECTIVES": sys.argv[2],
-  "BRANCH": sys.argv[3]
+  "BRANCH": sys.argv[3],
+  "SDD_DOCS_LOCATION": sys.argv[4],
+  "SDD_ROOT": sys.argv[5]
 }))
 PY

--- a/skills/evals/evals-implement/scripts/powershell/setup-evals-implement.ps1
+++ b/skills/evals/evals-implement/scripts/powershell/setup-evals-implement.ps1
@@ -29,6 +29,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -37,12 +62,23 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
 
 $result = @{
     REPO_ROOT = $ProjectRoot
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+    SDD_ROOT = $SddRoot
 }
 
 $result | ConvertTo-Json -Compress

--- a/skills/evals/evals-init/SKILL.md
+++ b/skills/evals/evals-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evals-init
-description: Initialize evals/{system}/ directory structure for evaluation system following EDD principles (Standalone). Choose PromptFoo or DeepEval based on tech stack, generate security baseline.
+description: Initialize $SDD_ROOT/evals/{system}/ directory structure for evaluation system following EDD principles (Standalone). Choose PromptFoo or DeepEval based on tech stack, generate security baseline.
 disable-model-invocation: true
 ---
 
@@ -11,9 +11,9 @@ disable-model-invocation: true
 Initialize the **project-level evaluation directory structure** following EDD (Eval-Driven Development) principles to prepare for systematic evaluation development. This is completely standalone with zero spec-kit dependencies.
 
 **Output**:
-1. **Directory Structure** - `evals/{system}/` with proper organization (promptfoo | deepeval)
+1. **Directory Structure** - `$SDD_ROOT/evals/{system}/` with proper organization (promptfoo | deepeval)
 2. **Security Baseline** - Auto-created graders for PII leakage, prompt injection, hallucination detection, misinformation detection
-3. **Configuration Files** - Standalone config.yml and goldset templates under `.adlc/evals/`
+3. **Configuration Files** - Standalone config.yml and goldset templates under `$SDD_ROOT/.adlc/evals/`
 4. **Auto-handoff** to `/evals-specify` to begin error analysis
 
 **Key EDD Principles Applied**:
@@ -52,32 +52,33 @@ Parse flags from the arguments first, then treat remaining text as focus areas:
 #### Phase 2: Create Directory Structure
 Creates:
 ```
-evals/
-├── {system}/                    # promptfoo | deepeval
-│   ├── goldset.md              # Published goldset
-│   ├── goldset.json            # Auto-generated for system consumption
-│   ├── config.yml              # System-specific configuration
-│   ├── config.{js,py}          # Generated system config (.js for promptfoo, .py for deepeval)
-│   └── graders/                # Binary pass/fail graders
-│       ├── check_pii_leakage.py           # Security baseline
-│       ├── check_prompt_injection.py     # Security baseline
-│       ├── check_hallucination.py        # Security baseline
-│       └── check_misinformation.py       # Security baseline
-├── results/                    # Git-ignored run outputs
+$SDD_ROOT/
+├── evals/
+│   ├── {system}/               # promptfoo | deepeval
+│   │   ├── goldset.md          # Published goldset
+│   │   ├── goldset.json        # Auto-generated for system consumption
+│   │   ├── config.yml          # System-specific configuration
+│   │   ├── config.{js,py}      # Generated system config (.js for promptfoo, .py for deepeval)
+│   │   └── graders/            # Binary pass/fail graders
+│   │       ├── check_pii_leakage.py      # Security baseline
+│   │       ├── check_prompt_injection.py # Security baseline
+│   │       ├── check_hallucination.py    # Security baseline
+│   │       └── check_misinformation.py   # Security baseline
+│   └── results/                # Git-ignored run outputs
 └── .adlc/
     └── drafts/evals/           # Draft eval records (Markdown + YAML)
 ```
 
 #### Phase 3: Configuration Copy
-- Create `.adlc/evals/` if missing.
-- Copy `skills/evals/evals-templates/evals-config-template.yml` to `.adlc/evals/evals-config.yml`.
+- Create `$SDD_ROOT/.adlc/evals/` if missing.
+- Copy `skills/evals/evals-templates/evals-config-template.yml` to `$SDD_ROOT/.adlc/evals/evals-config.yml`.
 
 #### Phase 4: Auto-Handoff
 Trigger `/evals-specify` to begin error analysis.
 
 ## Verification
-- `evals/{system}/goldset.md` exists (initially empty)
-- `.adlc/evals/evals-config.yml` exists
+- `$SDD_ROOT/evals/{system}/goldset.md` exists (initially empty)
+- `$SDD_ROOT/.adlc/evals/evals-config.yml` exists
 - Graders directory populated with 4 security baseline python scripts
 - Results directory contains `.gitignore` to prevent versioning traces
 - Handover report generated with recommended framework and next steps

--- a/skills/evals/evals-init/scripts/powershell/setup-evals-init.ps1
+++ b/skills/evals/evals-init/scripts/powershell/setup-evals-init.ps1
@@ -29,6 +29,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -37,12 +62,23 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
 
 $result = @{
     REPO_ROOT = $ProjectRoot
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+    SDD_ROOT = $SddRoot
 }
 
 $result | ConvertTo-Json -Compress

--- a/skills/evals/evals-specify/SKILL.md
+++ b/skills/evals/evals-specify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evals-specify
-description: Extract eval criteria from product specs and production failure traces (bottom-up error analysis). Writes proposed criteria to .adlc/drafts/evals/.
+description: Extract eval criteria from product specs and production failure traces (bottom-up error analysis). Writes proposed criteria to $SDD_ROOT/.adlc/drafts/evals/.
 disable-model-invocation: true
 ---
 
@@ -11,7 +11,7 @@ disable-model-invocation: true
 Conducts **bottom-up error analysis** following **EDD Principles III & IX** (Error Analysis & Test Data as Code) to discover and document draft evaluation criteria from human observation of system failures.
 
 **Output**:
-1. **Draft Eval Records** - Individual `EVAL-*.md` files in `.adlc/drafts/evals/` with open coding notes
+1. **Draft Eval Records** - Individual `EVAL-*.md` files in `$SDD_ROOT/.adlc/drafts/evals/` with open coding notes
 2. **Error Pattern Documentation** - Bottom-up failure taxonomy from actual traces
 3. **Pass/Fail Examples** - Real examples that should pass/fail each criterion
 4. **Auto-handoff** to `/evals-clarify` for axial coding and clustering
@@ -57,15 +57,15 @@ Group patterns into draft criteria. For each:
 - Document real pass/fail examples directly from traces
 
 #### Phase 3: Create Draft Files
-- Copy `skills/evals/evals-templates/eval-criterion-template.md` to `.adlc/drafts/evals/EVAL-{NNN}.md`.
+- Copy `skills/evals/evals-templates/eval-criterion-template.md` to `$SDD_ROOT/.adlc/drafts/evals/EVAL-{NNN}.md`.
 - Populate metadata and error analysis notes.
-- Regenerate index at `.adlc/drafts/evals/evals.md`.
+- Regenerate index at `$SDD_ROOT/.adlc/drafts/evals/evals.md`.
 
 #### Phase 4: Auto-Handoff
 Trigger `/evals-clarify` for axial coding and clustering.
 
 ## Verification
-- Draft files created at `.adlc/drafts/evals/EVAL-*.md`
-- Index file `.adlc/drafts/evals/evals.md` updated with draft summaries
+- Draft files created at `$SDD_ROOT/.adlc/drafts/evals/EVAL-*.md`
+- Index file `$SDD_ROOT/.adlc/drafts/evals/evals.md` updated with draft summaries
 - Each draft contains: status "draft", pass/fail conditions, trace sources, and concrete examples
 - Auto-handoff context produced with list of created drafts

--- a/skills/evals/evals-specify/scripts/bash/setup-evals-specify.sh
+++ b/skills/evals/evals-specify/scripts/bash/setup-evals-specify.sh
@@ -33,19 +33,56 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
 
-python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" << 'PY'
+python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION" "$SDD_ROOT" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
   "TEAM_AI_DIRECTIVES": sys.argv[2],
-  "BRANCH": sys.argv[3]
+  "BRANCH": sys.argv[3],
+  "SDD_DOCS_LOCATION": sys.argv[4],
+  "SDD_ROOT": sys.argv[5]
 }))
 PY

--- a/skills/evals/evals-specify/scripts/powershell/setup-evals-specify.ps1
+++ b/skills/evals/evals-specify/scripts/powershell/setup-evals-specify.ps1
@@ -29,6 +29,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -37,12 +62,23 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
 
 $result = @{
     REPO_ROOT = $ProjectRoot
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+    SDD_ROOT = $SddRoot
 }
 
 $result | ConvertTo-Json -Compress

--- a/skills/evals/evals-validate/SKILL.md
+++ b/skills/evals/evals-validate/SKILL.md
@@ -48,11 +48,11 @@ $ARGUMENTS
 
 #### Phase 1: Execute Evaluations
 Runs the underlying framework CLI directly:
-- PromptFoo: `npx promptfoo eval --config evals/promptfoo/config.js`
-- DeepEval: `pytest evals/deepeval/ -v` or `python evals/deepeval/config.py`
+- PromptFoo: `npx promptfoo eval --config $SDD_ROOT/evals/promptfoo/config.js`
+- DeepEval: `pytest $SDD_ROOT/evals/deepeval/ -v` or `python $SDD_ROOT/evals/deepeval/config.py`
 
 #### Phase 2: Compute Statistical Validation
-- Parse generated results JSON from `evals/results/`.
+- Parse generated results JSON from `$SDD_ROOT/evals/results/`.
 - Calculate True Positive Rate (TPR) and True Negative Rate (TNR).
 - Calculate overall accuracy with 95% confidence intervals.
 - Ensure no Likert scales or numerical scores leak into results.
@@ -64,15 +64,15 @@ Runs the underlying framework CLI directly:
 - Check headroom analysis (SLA budget consumed).
 
 #### Phase 4: Write Validation Report
-- Write validation results to `evals/results/validation_report.md`.
+- Write validation results to `$SDD_ROOT/evals/results/validation_report.md`.
 - Include pass/fail counts, TPR/TNR table, SLA timings, and holdout set results.
 
 #### Phase 5: Auto-Handoff
 Trigger `/evals-analyze` to close the loop.
 
 ## Verification
-- Evaluation execution successfully completed with results JSON written to `evals/results/`
-- `evals/results/validation_report.md` created with TPR/TNR and SLA metrics
+- Evaluation execution successfully completed with results JSON written to `$SDD_ROOT/evals/results/`
+- `$SDD_ROOT/evals/results/validation_report.md` created with TPR/TNR and SLA metrics
 - Statistical metrics calculated with confidence intervals
 - Headroom and SLA compliance verified
 - Handover summary lists results and validation report path

--- a/skills/evals/evals-validate/scripts/bash/setup-evals-validate.sh
+++ b/skills/evals/evals-validate/scripts/bash/setup-evals-validate.sh
@@ -33,19 +33,56 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
 
-python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" << 'PY'
+python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION" "$SDD_ROOT" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
   "TEAM_AI_DIRECTIVES": sys.argv[2],
-  "BRANCH": sys.argv[3]
+  "BRANCH": sys.argv[3],
+  "SDD_DOCS_LOCATION": sys.argv[4],
+  "SDD_ROOT": sys.argv[5]
 }))
 PY

--- a/skills/evals/evals-validate/scripts/powershell/setup-evals-validate.ps1
+++ b/skills/evals/evals-validate/scripts/powershell/setup-evals-validate.ps1
@@ -29,6 +29,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -37,12 +62,23 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
 
 $result = @{
     REPO_ROOT = $ProjectRoot
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+    SDD_ROOT = $SddRoot
 }
 
 $result | ConvertTo-Json -Compress

--- a/skills/levelup/levelup-clarify/scripts/bash/setup-levelup-clarify.sh
+++ b/skills/levelup/levelup-clarify/scripts/bash/setup-levelup-clarify.sh
@@ -37,6 +37,34 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
@@ -47,8 +75,15 @@ resolve_branch() {
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
-CDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/cdr"
+CDR_DRAFTS_DIR="${SDD_ROOT}/.adlc/drafts/cdr"
 
 mkdir -p "$CDR_DRAFTS_DIR"
 
@@ -63,15 +98,16 @@ fi
 
 TD_CONFIGURED=$([[ -d "$TEAM_AI_DIRECTIVES" ]] && echo "true" || echo "false")
 
-python3 - "$PROJECT_ROOT" "$CDR_DRAFTS_DIR" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$PENDING_COUNT" "$ACCEPTED_COUNT" "$TD_CONFIGURED" << 'PY'
+python3 - "$PROJECT_ROOT" "$SDD_ROOT" "$CDR_DRAFTS_DIR" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$PENDING_COUNT" "$ACCEPTED_COUNT" "$TD_CONFIGURED" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
-  "CDR_DRAFTS_DIR": sys.argv[2],
-  "TEAM_AI_DIRECTIVES": sys.argv[3],
-  "BRANCH": sys.argv[4],
-  "PENDING_COUNT": int(sys.argv[5]),
-  "ACCEPTED_COUNT": int(sys.argv[6]),
-  "TD_CONFIGURED": sys.argv[7] == "true"
+  "SDD_ROOT": sys.argv[2],
+  "CDR_DRAFTS_DIR": sys.argv[3],
+  "TEAM_AI_DIRECTIVES": sys.argv[4],
+  "BRANCH": sys.argv[5],
+  "PENDING_COUNT": int(sys.argv[6]),
+  "ACCEPTED_COUNT": int(sys.argv[7]),
+  "TD_CONFIGURED": sys.argv[8] == "true"
 }))
 PY

--- a/skills/levelup/levelup-clarify/scripts/powershell/setup-levelup-clarify.ps1
+++ b/skills/levelup/levelup-clarify/scripts/powershell/setup-levelup-clarify.ps1
@@ -33,6 +33,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -45,8 +70,17 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
-$CdrDraftsDir = Join-Path $ProjectRoot ".adlc/drafts/cdr"
+$CdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/cdr"
 
 New-Item -ItemType Directory -Path $CdrDraftsDir -Force | Out-Null
 
@@ -66,6 +100,7 @@ $TdConfigured = if (Test-Path $TeamAiDirectives) { "true" } else { "false" }
 
 $result = @{
     REPO_ROOT = $ProjectRoot
+    SDD_ROOT = $SddRoot
     CDR_DRAFTS_DIR = $CdrDraftsDir
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch

--- a/skills/levelup/levelup-init/scripts/bash/setup-levelup-init.sh
+++ b/skills/levelup/levelup-init/scripts/bash/setup-levelup-init.sh
@@ -37,6 +37,34 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
@@ -61,10 +89,17 @@ next_cdr_number() {
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
-CDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/cdr"
-SKILLS_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/skills"
-LEVELUP_STATE_FILE="${PROJECT_ROOT}/.adlc/levelup/state.json"
+CDR_DRAFTS_DIR="${SDD_ROOT}/.adlc/drafts/cdr"
+SKILLS_DRAFTS_DIR="${SDD_ROOT}/.adlc/drafts/skills"
+LEVELUP_STATE_FILE="${SDD_ROOT}/.adlc/levelup/state.json"
 
 mkdir -p "$CDR_DRAFTS_DIR" "$SKILLS_DRAFTS_DIR" "$(dirname "$LEVELUP_STATE_FILE")"
 
@@ -72,17 +107,18 @@ NEXT_CDR=$(next_cdr_number "$CDR_DRAFTS_DIR")
 EXISTING_CDRS=$( { ls -1 "$CDR_DRAFTS_DIR"/CDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
 TD_CONFIGURED=$([[ -d "$TEAM_AI_DIRECTIVES" ]] && echo "true" || echo "false")
 
-python3 - "$PROJECT_ROOT" "$CDR_DRAFTS_DIR" "$SKILLS_DRAFTS_DIR" "$LEVELUP_STATE_FILE" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$NEXT_CDR" "$EXISTING_CDRS" "$TD_CONFIGURED" << 'PY'
+python3 - "$PROJECT_ROOT" "$SDD_ROOT" "$CDR_DRAFTS_DIR" "$SKILLS_DRAFTS_DIR" "$LEVELUP_STATE_FILE" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$NEXT_CDR" "$EXISTING_CDRS" "$TD_CONFIGURED" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
-  "CDR_DRAFTS_DIR": sys.argv[2],
-  "SKILLS_DRAFTS_DIR": sys.argv[3],
-  "LEVELUP_STATE_FILE": sys.argv[4],
-  "TEAM_AI_DIRECTIVES": sys.argv[5],
-  "BRANCH": sys.argv[6],
-  "NEXT_CDR": sys.argv[7],
-  "EXISTING_CDRS": int(sys.argv[8]),
-  "TD_CONFIGURED": sys.argv[9] == "true"
+  "SDD_ROOT": sys.argv[2],
+  "CDR_DRAFTS_DIR": sys.argv[3],
+  "SKILLS_DRAFTS_DIR": sys.argv[4],
+  "LEVELUP_STATE_FILE": sys.argv[5],
+  "TEAM_AI_DIRECTIVES": sys.argv[6],
+  "BRANCH": sys.argv[7],
+  "NEXT_CDR": sys.argv[8],
+  "EXISTING_CDRS": int(sys.argv[9]),
+  "TD_CONFIGURED": sys.argv[10] == "true"
 }))
 PY

--- a/skills/levelup/levelup-init/scripts/powershell/setup-levelup-init.ps1
+++ b/skills/levelup/levelup-init/scripts/powershell/setup-levelup-init.ps1
@@ -33,6 +33,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -58,10 +83,19 @@ function Get-NextCdrNumber {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
-$CdrDraftsDir = Join-Path $ProjectRoot ".adlc/drafts/cdr"
-$SkillsDraftsDir = Join-Path $ProjectRoot ".adlc/drafts/skills"
-$LevelupStateFile = Join-Path $ProjectRoot ".adlc/levelup/state.json"
+$CdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/cdr"
+$SkillsDraftsDir = Join-Path $SddRoot ".adlc/drafts/skills"
+$LevelupStateFile = Join-Path $SddRoot ".adlc/levelup/state.json"
 
 New-Item -ItemType Directory -Path $CdrDraftsDir -Force | Out-Null
 New-Item -ItemType Directory -Path $SkillsDraftsDir -Force | Out-Null
@@ -73,6 +107,7 @@ $TdConfigured = if (Test-Path $TeamAiDirectives) { "true" } else { "false" }
 
 $result = @{
     REPO_ROOT = $ProjectRoot
+    SDD_ROOT = $SddRoot
     CDR_DRAFTS_DIR = $CdrDraftsDir
     SKILLS_DRAFTS_DIR = $SkillsDraftsDir
     LEVELUP_STATE_FILE = $LevelupStateFile

--- a/skills/levelup/levelup-publish/SKILL.md
+++ b/skills/levelup/levelup-publish/SKILL.md
@@ -438,20 +438,26 @@ If `AGENTS.md` is missing, create it from a template.
 
 #### Phase 10: Commit and PR
 
-Verify files created, then follow the git decision tree:
+Verify files created, then publish using the shared git workflow.
 
-**Case A: team-ai-directives IS a git repo (`TD_IS_GIT=true`)**
+**Source shared helpers** (resolves to the helpers file from either the source repo or an installed flat layout):
 
-1. Create branch (use `main` if it exists, otherwise `HEAD`):
 ```bash
-cd "$TEAM_AI_DIRECTIVES"
-git checkout -b "levelup/$(basename "$REPO_ROOT")" main 2>/dev/null || git checkout -b "levelup/$(basename "$REPO_ROOT")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEAM_HELPERS=""
+for candidate in \
+  "${SCRIPT_DIR}/../../team/team-helpers.sh" \
+  "${SCRIPT_DIR}/../team-helpers.sh" \
+  "${SCRIPT_DIR}/team-helpers.sh"; do
+  [[ -f "$candidate" ]] && { TEAM_HELPERS="$candidate"; break; }
+done
+[[ -n "$TEAM_HELPERS" ]] && source "$TEAM_HELPERS"
 ```
 
-2. Commit:
+**Construct the commit message**:
+
 ```bash
-git add -A
-git commit -m "Add context modules from $(basename "$REPO_ROOT")
+COMMIT_MSG="Add context modules from $(basename "$REPO_ROOT")
 
 CDRs implemented:
 - CDR-001: ...
@@ -459,42 +465,44 @@ CDRs implemented:
 "
 ```
 
-3. Check for a remote:
+**Invoke the shared publish workflow**:
+
 ```bash
-git remote get-url origin 2>/dev/null
+READY_FLAG=""  # set to "--ready" if user passed --ready
+git_publish_workflow "$TEAM_AI_DIRECTIVES" "levelup" "$COMMIT_MSG" "$READY_FLAG"
 ```
 
-4a. **If remote "origin" exists AND `gh` CLI is available** — push and create draft PR:
-```bash
-git push -u origin "levelup/$(basename "$REPO_ROOT")"
-gh pr create --draft --title "Add context modules from $(basename "$REPO_ROOT")" --body "..."
+PowerShell equivalent:
+
+```powershell
+$ProjectRoot = $env:PROJECT_ROOT -or (git rev-parse --show-toplevel 2>$null) -or (Get-Location).Path
+$CommitMsg = @"
+Add context modules from $(Split-Path $ProjectRoot -Leaf)
+
+CDRs implemented:
+- CDR-001: ...
+- CDR-002: ...
+"@
+Invoke-GitPublishWorkflow -TargetDir "$env:TEAM_AI_DIRECTIVES" -BranchPrefix "levelup" -CommitMsg $CommitMsg
 ```
 
-4b. **If remote "origin" exists but `gh` is NOT available** — push only, tell user to open PR manually:
-```bash
-git push -u origin "levelup/$(basename "$REPO_ROOT")"
-```
-Report: "Pushed to `origin/levelup/{project-name}`. Open a PR manually at your Git host."
+The workflow follows the same decision tree for any target directory:
 
-4c. **If no remote exists** — commit locally only. Report: "Committed to local branch `levelup/{project-name}`. Add a remote (`git remote add origin <url>`) and push when ready."
+**Case A: target directory IS a git repo and has a remote**
 
-**Case B: team-ai-directives is NOT a git repo (`TD_IS_GIT=false`)**
+- With `gh` CLI available: push branch and create a draft PR (or ready PR if `--ready` was passed).
+- Without `gh`: push branch and report manual-PR instructions.
 
-Offer the user two options:
+**Case B: target directory IS a git repo but has no remote**
 
-1. **`git init` + commit** — initialize git, create an initial commit with the scaffold, then commit the new context modules:
-```bash
-cd "$TEAM_AI_DIRECTIVES"
-git init
-git add -A
-git commit -m "Initial team-ai-directives scaffold"
-git checkout -b "levelup/$(basename "$REPO_ROOT")"
-git add -A
-git commit -m "Add context modules from $(basename "$REPO_ROOT")"
-```
-Then follow steps 3–4 above (remote check).
+Commit locally and report: "Committed to local branch `levelup/{project-name}`. Add a remote (`git remote add origin <url>`) and push when ready."
 
-2. **Write files only** — skip all git operations. Files are written directly to the working tree. Report: "Files written to `{TEAM_AI_DIRECTIVES}`. Initialize git and commit when ready."
+**Case C: target directory is NOT a git repo**
+
+Offer two options:
+
+1. **`git init` + commit** — initialize git, create an initial scaffold commit, then run the workflow again.
+2. **Write files only** — skip all git operations. Report: "Files written to `{TEAM_AI_DIRECTIVES}`. Initialize git and commit when ready."
 
 #### Phase 11: Summary
 

--- a/skills/levelup/levelup-publish/scripts/bash/setup-levelup-publish.sh
+++ b/skills/levelup/levelup-publish/scripts/bash/setup-levelup-publish.sh
@@ -37,6 +37,34 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
@@ -47,9 +75,16 @@ resolve_branch() {
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
-CDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/cdr"
-SKILLS_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/skills"
+CDR_DRAFTS_DIR="${SDD_ROOT}/.adlc/drafts/cdr"
+SKILLS_DRAFTS_DIR="${SDD_ROOT}/.adlc/drafts/skills"
 
 mkdir -p "$CDR_DRAFTS_DIR" "$SKILLS_DRAFTS_DIR"
 
@@ -61,7 +96,7 @@ if [[ -d "$CDR_DRAFTS_DIR" ]]; then
   done < <(grep -l -E '^### Status: \*\*Accepted\*\*' "$CDR_DRAFTS_DIR"/CDR-*.md 2>/dev/null | sort)
 fi
 
-ACCEPTED_JSON=$(printf '%s\n' "${ACCEPTED_CDRS[@]}" | python3 -c 'import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+ACCEPTED_JSON=$(printf '%s\n' ${ACCEPTED_CDRS[@]+"${ACCEPTED_CDRS[@]}"} | python3 -c 'import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
 TD_CONFIGURED=$([[ -d "$TEAM_AI_DIRECTIVES" ]] && echo "true" || echo "false")
 
 # Check if team-ai-directives is a git repo with a clean working tree
@@ -74,17 +109,18 @@ if [[ "$TD_CONFIGURED" == "true" ]]; then
   fi
 fi
 
-python3 - "$PROJECT_ROOT" "$CDR_DRAFTS_DIR" "$SKILLS_DRAFTS_DIR" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$ACCEPTED_JSON" "$TD_CONFIGURED" "$TD_IS_GIT" "$TD_CLEAN" << 'PY'
+python3 - "$PROJECT_ROOT" "$SDD_ROOT" "$CDR_DRAFTS_DIR" "$SKILLS_DRAFTS_DIR" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$ACCEPTED_JSON" "$TD_CONFIGURED" "$TD_IS_GIT" "$TD_CLEAN" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
-  "CDR_DRAFTS_DIR": sys.argv[2],
-  "SKILLS_DRAFTS_DIR": sys.argv[3],
-  "TEAM_AI_DIRECTIVES": sys.argv[4],
-  "BRANCH": sys.argv[5],
-  "ACCEPTED_CDRS": json.loads(sys.argv[6]),
-  "TD_CONFIGURED": sys.argv[7] == "true",
-  "TD_IS_GIT": sys.argv[8] == "true",
-  "TD_CLEAN": sys.argv[9] == "true"
+  "SDD_ROOT": sys.argv[2],
+  "CDR_DRAFTS_DIR": sys.argv[3],
+  "SKILLS_DRAFTS_DIR": sys.argv[4],
+  "TEAM_AI_DIRECTIVES": sys.argv[5],
+  "BRANCH": sys.argv[6],
+  "ACCEPTED_CDRS": json.loads(sys.argv[7]),
+  "TD_CONFIGURED": sys.argv[8] == "true",
+  "TD_IS_GIT": sys.argv[9] == "true",
+  "TD_CLEAN": sys.argv[10] == "true"
 }))
 PY

--- a/skills/levelup/levelup-publish/scripts/powershell/setup-levelup-publish.ps1
+++ b/skills/levelup/levelup-publish/scripts/powershell/setup-levelup-publish.ps1
@@ -33,6 +33,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -45,9 +70,18 @@ function Resolve-Branch {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
-$CdrDraftsDir = Join-Path $ProjectRoot ".adlc/drafts/cdr"
-$SkillsDraftsDir = Join-Path $ProjectRoot ".adlc/drafts/skills"
+$CdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/cdr"
+$SkillsDraftsDir = Join-Path $SddRoot ".adlc/drafts/skills"
 
 New-Item -ItemType Directory -Path $CdrDraftsDir -Force | Out-Null
 New-Item -ItemType Directory -Path $SkillsDraftsDir -Force | Out-Null
@@ -79,6 +113,7 @@ if ($TdConfigured -eq "true") {
 
 $result = @{
     REPO_ROOT = $ProjectRoot
+    SDD_ROOT = $SddRoot
     CDR_DRAFTS_DIR = $CdrDraftsDir
     SKILLS_DRAFTS_DIR = $SkillsDraftsDir
     TEAM_AI_DIRECTIVES = $TeamAiDirectives

--- a/skills/levelup/levelup-specify/scripts/bash/setup-levelup-specify.sh
+++ b/skills/levelup/levelup-specify/scripts/bash/setup-levelup-specify.sh
@@ -37,6 +37,34 @@ except Exception:
   echo "${project_root}/team-ai-directives"
 }
 
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
 resolve_branch() {
   git branch --show-current 2>/dev/null || echo "unknown"
 }
@@ -61,8 +89,15 @@ next_cdr_number() {
 
 PROJECT_ROOT=$(resolve_project_root)
 TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
 BRANCH=$(resolve_branch)
-CDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/cdr"
+CDR_DRAFTS_DIR="${SDD_ROOT}/.adlc/drafts/cdr"
 
 mkdir -p "$CDR_DRAFTS_DIR"
 
@@ -70,15 +105,16 @@ NEXT_CDR=$(next_cdr_number "$CDR_DRAFTS_DIR")
 EXISTING_CDRS=$( { ls -1 "$CDR_DRAFTS_DIR"/CDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
 TD_CONFIGURED=$([[ -d "$TEAM_AI_DIRECTIVES" ]] && echo "true" || echo "false")
 
-python3 - "$PROJECT_ROOT" "$CDR_DRAFTS_DIR" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$NEXT_CDR" "$EXISTING_CDRS" "$TD_CONFIGURED" << 'PY'
+python3 - "$PROJECT_ROOT" "$SDD_ROOT" "$CDR_DRAFTS_DIR" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$NEXT_CDR" "$EXISTING_CDRS" "$TD_CONFIGURED" << 'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
-  "CDR_DRAFTS_DIR": sys.argv[2],
-  "TEAM_AI_DIRECTIVES": sys.argv[3],
-  "BRANCH": sys.argv[4],
-  "NEXT_CDR": sys.argv[5],
-  "EXISTING_CDRS": int(sys.argv[6]),
-  "TD_CONFIGURED": sys.argv[7] == "true"
+  "SDD_ROOT": sys.argv[2],
+  "CDR_DRAFTS_DIR": sys.argv[3],
+  "TEAM_AI_DIRECTIVES": sys.argv[4],
+  "BRANCH": sys.argv[5],
+  "NEXT_CDR": sys.argv[6],
+  "EXISTING_CDRS": int(sys.argv[7]),
+  "TD_CONFIGURED": sys.argv[8] == "true"
 }))
 PY

--- a/skills/levelup/levelup-specify/scripts/powershell/setup-levelup-specify.ps1
+++ b/skills/levelup/levelup-specify/scripts/powershell/setup-levelup-specify.ps1
@@ -33,6 +33,31 @@ function Resolve-TeamAiDirectives {
     return (Join-Path $ProjectRoot "team-ai-directives")
 }
 
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
 function Resolve-Branch {
     $b = git branch --show-current 2>$null
     if ($b) { return $b }
@@ -58,8 +83,17 @@ function Get-NextCdrNumber {
 
 $ProjectRoot = Resolve-ProjectRoot
 $TeamAiDirectives = Resolve-TeamAiDirectives $ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
 $Branch = Resolve-Branch
-$CdrDraftsDir = Join-Path $ProjectRoot ".adlc/drafts/cdr"
+$CdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/cdr"
 
 New-Item -ItemType Directory -Path $CdrDraftsDir -Force | Out-Null
 
@@ -69,6 +103,7 @@ $TdConfigured = if (Test-Path $TeamAiDirectives) { "true" } else { "false" }
 
 $result = @{
     REPO_ROOT = $ProjectRoot
+    SDD_ROOT = $SddRoot
     CDR_DRAFTS_DIR = $CdrDraftsDir
     TEAM_AI_DIRECTIVES = $TeamAiDirectives
     BRANCH = $Branch

--- a/skills/mission-brief/SKILL.md
+++ b/skills/mission-brief/SKILL.md
@@ -84,21 +84,76 @@ state: report "No interrupted mission found" and stop.
 **Feature name derivation**: slugify the description to lowercase-hyphenated,
 drop stop words (a, an, the, new, to, with, for, add, fix, update). Example:
 "add a new react dashboard with telemetry" → `react-dashboard-telemetry`.
-If `.adlc/workflow/runs/` already contains a dir with that name, append `-2`,
+If `$SDD_ROOT/.adlc/workflow/runs/` already contains a dir with that name, append `-2`,
 `-3`, etc.
 
 ## Flow
 
-> **All paths are relative to the current working directory** (the project
-> root where the agent operates). Do not look in subdirectories for config or
-> state unless explicitly stated.
+> **All paths are relative to `$SDD_ROOT`** (the project root, unless `sdd_docs_location`
+> is configured, in which case the external location's per-project subfolder).
+> Do not look in subdirectories for config or state unless explicitly stated.
 
 ### Phase 0 — Configuration
 
-1. `mkdir -p .adlc/workflow` (and `.adlc/workflow/tmp`, `.adlc/workflow/runs`).
-2. If `.adlc/workflow/workflow-config.yml` does not exist, copy it from the
+1. Add an explicit resolution step that computes `PROJECT_ROOT`, `SDD_DOCS_LOCATION`,
+   `SDD_ROOT`, and `PROJECT_SUBFOLDER`. You may source `skills/team/team-helpers.sh`
+   and call its helpers, or use this equivalent inline bash:
+
+   ```bash
+   PROJECT_ROOT="$(pwd)"
+
+   resolve_sdd_docs_location() {
+     local sdd_docs_location=""
+     if [[ -n "${SDD_DOCS_LOCATION:-}" ]]; then
+       sdd_docs_location="$SDD_DOCS_LOCATION"
+     else
+       local init_options="${PROJECT_ROOT}/.adlc/init-options.json"
+       if [[ -f "$init_options" ]]; then
+         sdd_docs_location=$(python3 -c "
+import json
+try:
+    with open('$init_options') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+       fi
+     fi
+     echo "$sdd_docs_location"
+   }
+
+   sdd_project_subfolder_name() {
+     local common_dir
+     common_dir=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
+     if [[ -n "$common_dir" ]]; then
+       basename "$(cd "$(dirname "$common_dir")" && pwd)"
+     else
+       basename "$PROJECT_ROOT"
+     fi
+   }
+
+   SDD_DOCS_LOCATION=$(resolve_sdd_docs_location)
+   if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+     SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"  # expand tilde
+     PROJECT_SUBFOLDER=$(sdd_project_subfolder_name)
+     SDD_ROOT="${SDD_DOCS_LOCATION%/}/${PROJECT_SUBFOLDER}"
+   else
+     SDD_ROOT="$PROJECT_ROOT"
+   fi
+   ```
+
+   **Note**: `PROJECT_SUBFOLDER` is derived from the git common-dir's parent
+   directory name (stable across `git worktree add` checkouts of the same
+   repo), matching every setup script that resolves `SDD_ROOT` — do NOT
+   derive it from the git remote URL, which would point mission-brief at a
+   different `SDD_ROOT` than the one the spec/architect/evals skills write to.
+
+   **Important**: `.adlc/init-options.json` itself is read from `PROJECT_ROOT`
+   (above), not from `SDD_ROOT`. All other paths in this skill use `SDD_ROOT`.
+2. `mkdir -p "$SDD_ROOT/.adlc/workflow"` (and `"$SDD_ROOT/.adlc/workflow/tmp"`, `"$SDD_ROOT/.adlc/workflow/runs"`).
+3. If `"$SDD_ROOT/.adlc/workflow/workflow-config.yml"` does not exist, copy it from the
    skill's `config-template.yml` (located alongside this SKILL.md).
-3. Read `.adlc/workflow/workflow-config.yml`. Defaults if fields are absent:
+4. Read `"$SDD_ROOT/.adlc/workflow/workflow-config.yml"`. Defaults if fields are absent:
 
 ```yaml
 workflow:
@@ -118,13 +173,13 @@ this run.
 
 ### Phase 1 — Resume check (`--resume` only)
 
-> `<FEATURE_DIR>` = `.adlc/workflow/runs/<feature>/` (defined in Phase 4, but
+> `<FEATURE_DIR>` = `"$SDD_ROOT/.adlc/workflow/runs/<feature>/"` (defined in Phase 4, but
 > referenced here for the completed-mission check).
 
 If `--resume` was passed:
 
-1. Read `.adlc/workflow/.mission-state.json`.
-2. If `<FEATURE_DIR>/mission-log.json` exists → report "Mission already
+1. Read `"$SDD_ROOT/.adlc/workflow/.mission-state.json"`.
+2. If `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"` exists → report "Mission already
    completed for feature X. Audit trail: …" → stop.
 3. If state exists with non-empty `completed_steps` → resume: load the step
    list from `state.steps`, skip to Phase 5 (Execute) at the first incomplete
@@ -161,7 +216,7 @@ Structure `spec_description` into the Mission Brief template:
   without confirmation.
 - `--async` → proceed without confirmation (autonomous, ungated).
 
-Store the brief in `.mission-state.json.brief`.
+Store the brief in `"$SDD_ROOT/.adlc/workflow/.mission-state.json.brief"`.
 
 ### Phase 3 — Route classification & optional phases
 
@@ -413,7 +468,7 @@ For each step with `status: pending`:
      consult `references/agent-integrations.md` for known locations."
 
 4. Wait for the subagent.
-5. **Update `.mission-state.json` now** — before the next step. Store the
+5. **Update `"$SDD_ROOT/.adlc/workflow/.mission-state.json"` now** — before the next step. Store the
    subagent's returned values in state under `step_results.<id>`:
    - Store 1-2 sentence summary as `step_results.<id>.output`
    - Store confidence score as `step_results.<id>.confidence` (if provided, otherwise default to `HIGH`)
@@ -513,11 +568,11 @@ When all steps complete (or a signal forces a return), act on the signal:
 **`converged` or `tasks_appended`** (loop finished):
 
 - sync + gated/hybrid → **require human sign-off**: display the audit trail
-  from `iterations.md`; ask "Convergence passed. Review and approve
+  from `"$SDD_ROOT/.adlc/workflow/runs/<feature>/iterations.md"`; ask "Convergence passed. Review and approve
   completion?" → approve proceeds; reject pauses ("Mission paused for review.
   Run `mission-brief --resume` after addressing issues.").
 - sync + autonomous, or `--async` → skip sign-off.
-- Move `.mission-state.json` → `.adlc/workflow/runs/<feature>/mission-log.json`
+- Move `"$SDD_ROOT/.adlc/workflow/.mission-state.json"` → `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"`
   (audit trail — not deleted).
 - Report:
   ```
@@ -528,7 +583,7 @@ When all steps complete (or a signal forces a return), act on the signal:
   - Supervision: <mode>
   - Signal: <converged|tasks_appended>
   - Spec corrections: <n>/<max>
-  - Audit trail: .adlc/workflow/runs/<feature>/mission-log.json
+  - Audit trail: `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"`
   ```
 
 **`failed`**: report the error; keep state for inspection. User can re-run
@@ -557,8 +612,8 @@ When all steps complete (or a signal forces a return), act on the signal:
 - **Quality threshold**: if configured, blocks DONE below threshold —
   treats as CONTINUE instead.
 - **Converge independence hint**: converge subagent verifies independently.
-- **Audit trail**: `iterations.md` + `mission-log.json` — not deleted.
-- **State persistence**: `.mission-state.json` survives compaction/restarts.
+- **Audit trail**: `"$SDD_ROOT/.adlc/workflow/runs/<feature>/iterations.md"` + `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"` — not deleted.
+- **State persistence**: `"$SDD_ROOT/.adlc/workflow/.mission-state.json"` survives compaction/restarts.
 - **Resume is explicit**: `mission-brief --resume`; fresh `mission-brief` asks
   before clobbering an interrupted state.
 
@@ -575,7 +630,7 @@ When all steps complete (or a signal forces a return), act on the signal:
 
 ## Red Flags
 
-- Executing steps without writing `.mission-state.json` after each one.
+- Executing steps without writing `"$SDD_ROOT/.adlc/workflow/.mission-state.json"` after each one.
 - Inserting gates in an `--async` run.
 - Skipping the Mission Brief in autonomous mode when Success Criteria are
   "TBD".
@@ -583,8 +638,8 @@ When all steps complete (or a signal forces a return), act on the signal:
   summarizing + discarding.
 - Clobbering an interrupted state without asking (fresh `mission-brief`
   without `--resume`).
-- Deleting `.mission-state.json` on completion instead of moving it to
-  `mission-log.json`.
+- Deleting `"$SDD_ROOT/.adlc/workflow/.mission-state.json"` on completion instead of moving it to
+  `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"`.
 - Hardcoding a specific agent's commands directory instead of using the
   discovered paths from `state.discovered`.
 - Ignoring a `SPEC_CORRECTION_NEEDED` signal from the converge subagent
@@ -595,16 +650,16 @@ When all steps complete (or a signal forces a return), act on the signal:
 
 ## Verification
 
-- `.adlc/workflow/workflow-config.yml` exists (copied from template if
+- `"$SDD_ROOT/.adlc/workflow/workflow-config.yml"` exists (copied from template if
   absent).
-- `.mission-state.json` contains: `brief` (goal/constraints/success criteria),
+- `"$SDD_ROOT/.adlc/workflow/.mission-state.json"` contains: `brief` (goal/constraints/success criteria),
   `steps` (ordered list with phase/tier/prompt/status), `discovered`
   (skills_dirs + commands_dirs + local_skills), `completed_steps` (grows monotonically).
-- `iterations.md` gains an entry per implement step.
-- On completion, `mission-log.json` exists under
-  `.adlc/workflow/runs/<feature>/`.
+- `"$SDD_ROOT/.adlc/workflow/runs/<feature>/iterations.md"` gains an entry per implement step.
+- On completion, `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"` exists under
+  `"$SDD_ROOT/.adlc/workflow/runs/<feature>/"`.
 - A `--resume` with no state reports "No interrupted mission found" and stops.
-- A `--resume` with `mission-log.json` present reports "already completed".
+- A `--resume` with `"$SDD_ROOT/.adlc/workflow/runs/<feature>/mission-log.json"` present reports "already completed".
 - The delegation prompt includes discovered paths (not a hardcoded list).
 - The delegation prompt includes `<LOCAL_SKILLS_LIST>` built from
   `discovered.local_skills` (empty list → "No custom skills detected").
@@ -620,7 +675,7 @@ When all steps complete (or a signal forces a return), act on the signal:
 
 ## Configuration
 
-- `.adlc/workflow/workflow-config.yml` — execution, supervision, budgets,
+- `"$SDD_ROOT/.adlc/workflow/workflow-config.yml"` — execution, supervision, budgets,
   quality threshold, optional models map. See `config-template.yml`.
 - `references/agent-integrations.md` — full agent→directory mapping table.
   Update when new agents are added or conventions change. The executor reads

--- a/skills/mission-brief/config-template.yml
+++ b/skills/mission-brief/config-template.yml
@@ -1,6 +1,6 @@
 # mission-brief — workflow configuration
 #
-# Copy to .adlc/workflow/workflow-config.yml in your project and edit.
+# Copy to $SDD_ROOT/.adlc/workflow/workflow-config.yml in your project and edit (project root by default, or the external `sdd_docs_location` subfolder if configured).
 # Every field is optional; defaults are shown below.
 
 workflow:

--- a/skills/product/product-analyze/scripts/bash/setup-product-analyze.sh
+++ b/skills/product/product-analyze/scripts/bash/setup-product-analyze.sh
@@ -1,16 +1,57 @@
 #!/bin/bash
 # product-analyze setup script
 set -euo pipefail
+
 JSON_MODE=false
 for arg in "$@"; do case "$arg" in --json) JSON_MODE=true ;; esac; done
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-PDR_DRAFTS_DIR="$REPO_ROOT/.adlc/drafts/pdr"
-PRD_FILE="$REPO_ROOT/PRD.md"
-PDR_COUNT=$(find "$PDR_DRAFTS_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l)
+
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+REPO_ROOT="$PROJECT_ROOT"
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+
+PDR_DRAFTS_DIR="$SDD_ROOT/.adlc/drafts/pdr"
+PDR_MEMORY_DIR="$SDD_ROOT/.adlc/memory/pdr"
+PRD_FILE="$SDD_ROOT/PRD.md"
+PDR_COUNT=$([[ -d "$PDR_DRAFTS_DIR" ]] && find "$PDR_DRAFTS_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l || echo 0)
 PRD_EXISTS=$([ -f "$PRD_FILE" ] && echo "true" || echo "false")
 if $JSON_MODE; then
   cat <<EOF
-{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PRD_FILE":"$PRD_FILE","pdr_count":$PDR_COUNT,"prd_exists":$PRD_EXISTS}
+{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","SDD_DOCS_LOCATION":"$SDD_DOCS_LOCATION","SDD_ROOT":"$SDD_ROOT","pdr_count":$PDR_COUNT,"prd_exists":$PRD_EXISTS}
 EOF
 else
   echo "[INFO] product-analyze setup"

--- a/skills/product/product-analyze/scripts/powershell/setup-product-analyze.ps1
+++ b/skills/product/product-analyze/scripts/powershell/setup-product-analyze.ps1
@@ -1,13 +1,53 @@
 # product-analyze setup script (PowerShell)
 param([switch]$Json)
 $ErrorActionPreference = "Stop"
-$RepoRoot = $(git rev-parse --show-toplevel 2>$null); if (-not $RepoRoot) { $RepoRoot = Get-Location }
-$PdrDraftsDir = Join-Path $RepoRoot ".adlc/drafts/pdr"
-$PrdFile = Join-Path $RepoRoot "PRD.md"
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$RepoRoot = $(git rev-parse --show-toplevel 2>$null)
+if (-not $RepoRoot) { $RepoRoot = (Get-Location).Path }
+$ProjectRoot = $RepoRoot
+
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
+
+$PdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/pdr"
+$PdrMemoryDir = Join-Path $SddRoot ".adlc/memory/pdr"
+$PrdFile = Join-Path $SddRoot "PRD.md"
 $pdrCount = if (Test-Path $PdrDraftsDir) { (Get-ChildItem -Path $PdrDraftsDir -Filter 'PDR-*.md').Count } else { 0 }
 $prdExists = Test-Path $PrdFile
 if ($Json) {
-  Write-Output (@{ REPO_ROOT=$RepoRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PRD_FILE=$PrdFile; pdr_count=$pdrCount; prd_exists=$prdExists } | ConvertTo-Json)
+  Write-Output (@{ REPO_ROOT=$RepoRoot; SDD_DOCS_LOCATION=$SddDocsLocation; SDD_ROOT=$SddRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; pdr_count=$pdrCount; prd_exists=$prdExists } | ConvertTo-Json)
 } else {
   Write-Output "[INFO] product-analyze setup"
   Write-Output "  PDRs: $pdrCount"

--- a/skills/product/product-clarify/scripts/bash/setup-product-clarify.sh
+++ b/skills/product/product-clarify/scripts/bash/setup-product-clarify.sh
@@ -1,12 +1,53 @@
 #!/bin/bash
 # product-clarify setup script
 set -euo pipefail
+
 JSON_MODE=false
 for arg in "$@"; do case "$arg" in --json) JSON_MODE=true ;; esac; done
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-PDR_DRAFTS_DIR="$REPO_ROOT/.adlc/drafts/pdr"
-PDR_MEMORY_DIR="$REPO_ROOT/.adlc/memory/pdr"
-PRD_FILE="$REPO_ROOT/PRD.md"
+
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+REPO_ROOT="$PROJECT_ROOT"
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+
+PDR_DRAFTS_DIR="$SDD_ROOT/.adlc/drafts/pdr"
+PDR_MEMORY_DIR="$SDD_ROOT/.adlc/memory/pdr"
+PRD_FILE="$SDD_ROOT/PRD.md"
+
 mkdir -p "$PDR_DRAFTS_DIR"
 PDR_COUNT=$(find "$PDR_DRAFTS_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l)
 ACCEPTED_COUNT=0
@@ -15,7 +56,7 @@ if [[ "$PDR_COUNT" -gt 0 ]]; then
 fi
 if $JSON_MODE; then
   cat <<EOF
-{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","pdr_count":$PDR_COUNT,"accepted_count":$ACCEPTED_COUNT}
+{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","SDD_DOCS_LOCATION":"$SDD_DOCS_LOCATION","SDD_ROOT":"$SDD_ROOT","pdr_count":$PDR_COUNT,"accepted_count":$ACCEPTED_COUNT}
 EOF
 else
   echo "[INFO] product-clarify setup"

--- a/skills/product/product-clarify/scripts/powershell/setup-product-clarify.ps1
+++ b/skills/product/product-clarify/scripts/powershell/setup-product-clarify.ps1
@@ -1,10 +1,49 @@
 # product-clarify setup script (PowerShell)
 param([switch]$Json)
 $ErrorActionPreference = "Stop"
-$RepoRoot = $(git rev-parse --show-toplevel 2>$null); if (-not $RepoRoot) { $RepoRoot = Get-Location }
-$PdrDraftsDir = Join-Path $RepoRoot ".adlc/drafts/pdr"
-$PdrMemoryDir = Join-Path $RepoRoot ".adlc/memory/pdr"
-$PrdFile = Join-Path $RepoRoot "PRD.md"
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$RepoRoot = $(git rev-parse --show-toplevel 2>$null)
+if (-not $RepoRoot) { $RepoRoot = (Get-Location).Path }
+$ProjectRoot = $RepoRoot
+
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
+
+$PdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/pdr"
+$PdrMemoryDir = Join-Path $SddRoot ".adlc/memory/pdr"
+$PrdFile = Join-Path $SddRoot "PRD.md"
 New-Item -ItemType Directory -Force -Path $PdrDraftsDir | Out-Null
 $pdrCount = if (Test-Path $PdrDraftsDir) { (Get-ChildItem -Path $PdrDraftsDir -Filter 'PDR-*.md').Count } else { 0 }
 $acceptedCount = 0
@@ -15,7 +54,7 @@ if (Test-Path $PdrDraftsDir) {
   }
 }
 if ($Json) {
-  Write-Output (@{ REPO_ROOT=$RepoRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; pdr_count=$pdrCount; accepted_count=$acceptedCount } | ConvertTo-Json)
+  Write-Output (@{ REPO_ROOT=$RepoRoot; SDD_DOCS_LOCATION=$SddDocsLocation; SDD_ROOT=$SddRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; pdr_count=$pdrCount; accepted_count=$acceptedCount } | ConvertTo-Json)
 } else {
   Write-Output "[INFO] product-clarify setup"
   Write-Output "  PDRs found: $pdrCount"

--- a/skills/product/product-implement/scripts/bash/setup-product-implement.sh
+++ b/skills/product/product-implement/scripts/bash/setup-product-implement.sh
@@ -1,19 +1,59 @@
 #!/bin/bash
 # product-implement setup script
 set -euo pipefail
+
 JSON_MODE=false
 for arg in "$@"; do case "$arg" in --json) JSON_MODE=true ;; esac; done
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-PDR_DRAFTS_DIR="$REPO_ROOT/.adlc/drafts/pdr"
-PDR_MEMORY_DIR="$REPO_ROOT/.adlc/memory/pdr"
-PRD_FILE="$REPO_ROOT/PRD.md"
-SECTIONS_DIR="$REPO_ROOT/.adlc/product/sections"
-STATE_FILE="$REPO_ROOT/.adlc/product/state.json"
+
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+REPO_ROOT="$PROJECT_ROOT"
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+
+PDR_DRAFTS_DIR="$SDD_ROOT/.adlc/drafts/pdr"
+PDR_MEMORY_DIR="$SDD_ROOT/.adlc/memory/pdr"
+PRD_FILE="$SDD_ROOT/PRD.md"
+SECTIONS_DIR="$SDD_ROOT/.adlc/product/sections"
+STATE_FILE="$SDD_ROOT/.adlc/product/state.json"
 
 mkdir -p "$PDR_DRAFTS_DIR"
 mkdir -p "$PDR_MEMORY_DIR"
 mkdir -p "$SECTIONS_DIR"
-mkdir -p "$REPO_ROOT/.adlc/product"
+mkdir -p "$SDD_ROOT/.adlc/product"
 
 ACCEPTED_COUNT=0
 if [[ -d "$PDR_DRAFTS_DIR" ]]; then
@@ -26,7 +66,7 @@ fi
 
 if $JSON_MODE; then
   cat <<EOF
-{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","SECTIONS_DIR":"$SECTIONS_DIR","STATE_FILE":"$STATE_FILE","accepted_count":$ACCEPTED_COUNT}
+{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","SECTIONS_DIR":"$SECTIONS_DIR","STATE_FILE":"$STATE_FILE","SDD_DOCS_LOCATION":"$SDD_DOCS_LOCATION","SDD_ROOT":"$SDD_ROOT","accepted_count":$ACCEPTED_COUNT}
 EOF
 else
   echo "[INFO] product-implement setup"

--- a/skills/product/product-implement/scripts/powershell/setup-product-implement.ps1
+++ b/skills/product/product-implement/scripts/powershell/setup-product-implement.ps1
@@ -1,12 +1,51 @@
 # product-implement setup script (PowerShell)
 param([switch]$Json)
 $ErrorActionPreference = "Stop"
-$RepoRoot = $(git rev-parse --show-toplevel 2>$null); if (-not $RepoRoot) { $RepoRoot = Get-Location }
-$PdrDraftsDir = Join-Path $RepoRoot ".adlc/drafts/pdr"
-$PdrMemoryDir = Join-Path $RepoRoot ".adlc/memory/pdr"
-$PrdFile = Join-Path $RepoRoot "PRD.md"
-$SectionsDir = Join-Path $RepoRoot ".adlc/product/sections"
-$StateFile = Join-Path $RepoRoot ".adlc/product/state.json"
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$RepoRoot = $(git rev-parse --show-toplevel 2>$null)
+if (-not $RepoRoot) { $RepoRoot = (Get-Location).Path }
+$ProjectRoot = $RepoRoot
+
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
+
+$PdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/pdr"
+$PdrMemoryDir = Join-Path $SddRoot ".adlc/memory/pdr"
+$PrdFile = Join-Path $SddRoot "PRD.md"
+$SectionsDir = Join-Path $SddRoot ".adlc/product/sections"
+$StateFile = Join-Path $SddRoot ".adlc/product/state.json"
 New-Item -ItemType Directory -Force -Path $PdrDraftsDir | Out-Null
 New-Item -ItemType Directory -Force -Path $PdrMemoryDir | Out-Null
 New-Item -ItemType Directory -Force -Path $SectionsDir | Out-Null
@@ -20,7 +59,7 @@ if (Test-Path $PdrDraftsDir) {
 }
 
 if ($Json) {
-  Write-Output (@{ REPO_ROOT=$RepoRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; SECTIONS_DIR=$SectionsDir; STATE_FILE=$StateFile; accepted_count=$acceptedCount } | ConvertTo-Json)
+  Write-Output (@{ REPO_ROOT=$RepoRoot; SDD_DOCS_LOCATION=$SddDocsLocation; SDD_ROOT=$SddRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; SECTIONS_DIR=$SectionsDir; STATE_FILE=$StateFile; accepted_count=$acceptedCount } | ConvertTo-Json)
 } else {
   Write-Output "[INFO] product-implement setup"
   Write-Output "  Accepted PDRs: $acceptedCount"

--- a/skills/product/product-init/scripts/bash/setup-product-init.sh
+++ b/skills/product/product-init/scripts/bash/setup-product-init.sh
@@ -12,17 +12,68 @@ for arg in "$@"; do
   esac
 done
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-PDR_DRAFTS_DIR="$REPO_ROOT/.adlc/drafts/pdr"
-PRD_FILE="$REPO_ROOT/PRD.md"
+resolve_project_root() {
+  local dir
+  dir="$(pwd)"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -d "${dir}/.adlc" ]]; then
+      echo "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+PROJECT_ROOT=$(resolve_project_root)
+REPO_ROOT="$PROJECT_ROOT"
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+
+PDR_DRAFTS_DIR="$SDD_ROOT/.adlc/drafts/pdr"
+PRD_FILE="$SDD_ROOT/PRD.md"
 
 mkdir -p "$PDR_DRAFTS_DIR"
-mkdir -p "$REPO_ROOT/.adlc/product"
+mkdir -p "$SDD_ROOT/.adlc/product"
 
 # Detect feature areas from codebase structure
 detect_feature_areas() {
   local areas=()
-  local dir="$REPO_ROOT"
+  local dir="$PROJECT_ROOT"
 
   # Check common directory patterns
   for pattern in src features modules apps packages; do
@@ -56,13 +107,15 @@ detect_feature_areas() {
 
   # Deduplicate
   local unique=()
-  for a in "${areas[@]}"; do
-    local found=false
-    for u in "${unique[@]}"; do
-      if [[ "$u" == "$a" ]]; then found=true; break; fi
+  if [[ ${#areas[@]} -gt 0 ]]; then
+    for a in "${areas[@]}"; do
+      local found=false
+      for u in "${unique[@]}"; do
+        if [[ "$u" == "$a" ]]; then found=true; break; fi
+      done
+      if [[ "$found" == "false" ]]; then unique+=("$a"); fi
     done
-    if [[ "$found" == "false" ]]; then unique+=("$a"); fi
-  done
+  fi
 
   if [[ ${#unique[@]} -eq 0 ]]; then
     echo "Product"
@@ -111,6 +164,8 @@ if $JSON_MODE; then
   "REPO_ROOT": "$REPO_ROOT",
   "PDR_DRAFTS_DIR": "$PDR_DRAFTS_DIR",
   "PRD_FILE": "$PRD_FILE",
+  "SDD_DOCS_LOCATION": "$SDD_DOCS_LOCATION",
+  "SDD_ROOT": "$SDD_ROOT",
   "feature_areas": $FEATURE_AREAS_JSON,
   "next_pdr": "$NEXT_PDR",
   "pdr_count": $(find "$PDR_DRAFTS_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l)
@@ -119,6 +174,7 @@ EOF
 else
   echo "[INFO] product-init setup"
   echo "  REPO_ROOT: $REPO_ROOT"
+  echo "  SDD_ROOT: $SDD_ROOT"
   echo "  PDR_DRAFTS_DIR: $PDR_DRAFTS_DIR"
   echo "  Next PDR: PDR-$NEXT_PDR"
   echo "  Feature areas:"

--- a/skills/product/product-init/scripts/powershell/setup-product-init.ps1
+++ b/skills/product/product-init/scripts/powershell/setup-product-init.ps1
@@ -7,18 +7,67 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$RepoRoot = $(git rev-parse --show-toplevel 2>$null)
-if (-not $RepoRoot) { $RepoRoot = Get-Location }
+function Resolve-ProjectRoot {
+    $dir = (Get-Location).Path
+    $root = [System.IO.Path]::GetPathRoot($dir)
+    while ($dir -and $dir -ne $root) {
+        if (Test-Path (Join-Path $dir ".adlc") -PathType Container) {
+            return $dir
+        }
+        $dir = Split-Path $dir -Parent
+    }
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if ($gitRoot) { return $gitRoot }
+    return (Get-Location).Path
+}
 
-$PdrDraftsDir = Join-Path $RepoRoot ".adlc/drafts/pdr"
-$PrdFile = Join-Path $RepoRoot "PRD.md"
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$ProjectRoot = Resolve-ProjectRoot
+$RepoRoot = $ProjectRoot
+
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
+
+$PdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/pdr"
+$PrdFile = Join-Path $SddRoot "PRD.md"
 
 New-Item -ItemType Directory -Force -Path $PdrDraftsDir | Out-Null
-New-Item -ItemType Directory -Force -Path (Join-Path $RepoRoot ".adlc/product") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $SddRoot ".adlc/product") | Out-Null
 
 function Detect-FeatureAreas {
     $areas = @()
-    $dir = $RepoRoot
+    $dir = $ProjectRoot
 
     foreach ($pattern in @('src','features','modules','apps','packages')) {
         $path = Join-Path $dir $pattern
@@ -74,6 +123,8 @@ $faJson = ($featureAreas | ForEach-Object {
 if ($Json) {
     Write-Output (@{
         REPO_ROOT = $RepoRoot
+        SDD_DOCS_LOCATION = $SddDocsLocation
+        SDD_ROOT = $SddRoot
         PDR_DRAFTS_DIR = $PdrDraftsDir
         PRD_FILE = $PrdFile
         feature_areas = "[$faJson]"
@@ -83,6 +134,7 @@ if ($Json) {
 } else {
     Write-Output "[INFO] product-init setup"
     Write-Output "  REPO_ROOT: $RepoRoot"
+    Write-Output "  SDD_ROOT: $SddRoot"
     Write-Output "  PDR_DRAFTS_DIR: $PdrDraftsDir"
     Write-Output "  Next PDR: PDR-$nextPdr"
     Write-Output "  Feature areas:"

--- a/skills/product/product-roadmap/scripts/bash/setup-product-roadmap.sh
+++ b/skills/product/product-roadmap/scripts/bash/setup-product-roadmap.sh
@@ -1,18 +1,59 @@
 #!/bin/bash
 # product-roadmap setup script
 set -euo pipefail
+
 JSON_MODE=false
 for arg in "$@"; do case "$arg" in --json) JSON_MODE=true ;; esac; done
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-PDR_DRAFTS_DIR="$REPO_ROOT/.adlc/drafts/pdr"
-PDR_MEMORY_DIR="$REPO_ROOT/.adlc/memory/pdr"
-PRD_FILE="$REPO_ROOT/PRD.md"
-mkdir -p "$PDR_DRAFTS_DIR"
+
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+REPO_ROOT="$PROJECT_ROOT"
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+
+PDR_DRAFTS_DIR="$SDD_ROOT/.adlc/drafts/pdr"
+PDR_MEMORY_DIR="$SDD_ROOT/.adlc/memory/pdr"
+PRD_FILE="$SDD_ROOT/PRD.md"
+
+mkdir -p "$PDR_DRAFTS_DIR" "$PDR_MEMORY_DIR"
 DRAFT_COUNT=$(find "$PDR_DRAFTS_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l)
 MEM_COUNT=$(find "$PDR_MEMORY_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l)
 if $JSON_MODE; then
   cat <<EOF
-{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","draft_count":$DRAFT_COUNT,"memory_count":$MEM_COUNT}
+{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PDR_MEMORY_DIR":"$PDR_MEMORY_DIR","PRD_FILE":"$PRD_FILE","SDD_DOCS_LOCATION":"$SDD_DOCS_LOCATION","SDD_ROOT":"$SDD_ROOT","draft_count":$DRAFT_COUNT,"memory_count":$MEM_COUNT}
 EOF
 else
   echo "[INFO] product-roadmap setup"

--- a/skills/product/product-roadmap/scripts/powershell/setup-product-roadmap.ps1
+++ b/skills/product/product-roadmap/scripts/powershell/setup-product-roadmap.ps1
@@ -1,15 +1,54 @@
 # product-roadmap setup script (PowerShell)
 param([switch]$Json)
 $ErrorActionPreference = "Stop"
-$RepoRoot = $(git rev-parse --show-toplevel 2>$null); if (-not $RepoRoot) { $RepoRoot = Get-Location }
-$PdrDraftsDir = Join-Path $RepoRoot ".adlc/drafts/pdr"
-$PdrMemoryDir = Join-Path $RepoRoot ".adlc/memory/pdr"
-$PrdFile = Join-Path $RepoRoot "PRD.md"
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$RepoRoot = $(git rev-parse --show-toplevel 2>$null)
+if (-not $RepoRoot) { $RepoRoot = (Get-Location).Path }
+$ProjectRoot = $RepoRoot
+
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
+
+$PdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/pdr"
+$PdrMemoryDir = Join-Path $SddRoot ".adlc/memory/pdr"
+$PrdFile = Join-Path $SddRoot "PRD.md"
 New-Item -ItemType Directory -Force -Path $PdrDraftsDir | Out-Null
 $draftCount = if (Test-Path $PdrDraftsDir) { (Get-ChildItem -Path $PdrDraftsDir -Filter 'PDR-*.md').Count } else { 0 }
 $memCount = if (Test-Path $PdrMemoryDir) { (Get-ChildItem -Path $PdrMemoryDir -Filter 'PDR-*.md').Count } else { 0 }
 if ($Json) {
-  Write-Output (@{ REPO_ROOT=$RepoRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; draft_count=$draftCount; memory_count=$memCount } | ConvertTo-Json)
+  Write-Output (@{ REPO_ROOT=$RepoRoot; SDD_DOCS_LOCATION=$SddDocsLocation; SDD_ROOT=$SddRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PDR_MEMORY_DIR=$PdrMemoryDir; PRD_FILE=$PrdFile; draft_count=$draftCount; memory_count=$memCount } | ConvertTo-Json)
 } else {
   Write-Output "[INFO] product-roadmap setup"
   Write-Output "  Draft PDRs: $draftCount"

--- a/skills/product/product-specify/scripts/bash/setup-product-specify.sh
+++ b/skills/product/product-specify/scripts/bash/setup-product-specify.sh
@@ -7,9 +7,47 @@ for arg in "$@"; do
   case "$arg" in --json) JSON_MODE=true ;; esac
 done
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-PDR_DRAFTS_DIR="$REPO_ROOT/.adlc/drafts/pdr"
-PRD_FILE="$REPO_ROOT/PRD.md"
+resolve_sdd_docs_location() {
+  local project_root="$1"
+  local loc="${SDD_DOCS_LOCATION:-}"
+  [[ -n "$loc" ]] && { echo "$loc"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    loc=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+  fi
+  echo "$loc"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="$1"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+REPO_ROOT="$PROJECT_ROOT"
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+
+PDR_DRAFTS_DIR="$SDD_ROOT/.adlc/drafts/pdr"
+PRD_FILE="$SDD_ROOT/PRD.md"
 
 mkdir -p "$PDR_DRAFTS_DIR"
 
@@ -31,7 +69,7 @@ PDR_COUNT=$(find "$PDR_DRAFTS_DIR" -name 'PDR-*.md' 2>/dev/null | wc -l)
 
 if $JSON_MODE; then
   cat <<EOF
-{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PRD_FILE":"$PRD_FILE","next_pdr":"$NEXT_PDR","pdr_count":$PDR_COUNT}
+{"REPO_ROOT":"$REPO_ROOT","PDR_DRAFTS_DIR":"$PDR_DRAFTS_DIR","PRD_FILE":"$PRD_FILE","SDD_DOCS_LOCATION":"$SDD_DOCS_LOCATION","SDD_ROOT":"$SDD_ROOT","next_pdr":"$NEXT_PDR","pdr_count":$PDR_COUNT}
 EOF
 else
   echo "[INFO] product-specify setup"

--- a/skills/product/product-specify/scripts/powershell/setup-product-specify.ps1
+++ b/skills/product/product-specify/scripts/powershell/setup-product-specify.ps1
@@ -1,9 +1,48 @@
 # product-specify setup script (PowerShell)
 param([switch]$Json)
 $ErrorActionPreference = "Stop"
-$RepoRoot = $(git rev-parse --show-toplevel 2>$null); if (-not $RepoRoot) { $RepoRoot = Get-Location }
-$PdrDraftsDir = Join-Path $RepoRoot ".adlc/drafts/pdr"
-$PrdFile = Join-Path $RepoRoot "PRD.md"
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  if ($commonDir) {
+    $parent = Split-Path $commonDir -Parent
+    $normalized = (Resolve-Path $parent -ErrorAction SilentlyContinue).Path
+    if ($normalized) { return Split-Path $normalized -Leaf }
+  }
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$RepoRoot = $(git rev-parse --show-toplevel 2>$null)
+if (-not $RepoRoot) { $RepoRoot = (Get-Location).Path }
+$ProjectRoot = $RepoRoot
+
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") (Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot)
+} else {
+  $SddRoot = $ProjectRoot
+}
+
+$PdrDraftsDir = Join-Path $SddRoot ".adlc/drafts/pdr"
+$PrdFile = Join-Path $SddRoot "PRD.md"
 New-Item -ItemType Directory -Force -Path $PdrDraftsDir | Out-Null
 
 $max = 0
@@ -17,7 +56,7 @@ $nextPdr = '{0:D3}' -f ($max + 1)
 $pdrCount = if (Test-Path $PdrDraftsDir) { (Get-ChildItem -Path $PdrDraftsDir -Filter 'PDR-*.md').Count } else { 0 }
 
 if ($Json) {
-  Write-Output (@{ REPO_ROOT=$RepoRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PRD_FILE=$PrdFile; next_pdr=$nextPdr; pdr_count=$pdrCount } | ConvertTo-Json)
+  Write-Output (@{ REPO_ROOT=$RepoRoot; SDD_DOCS_LOCATION=$SddDocsLocation; SDD_ROOT=$SddRoot; PDR_DRAFTS_DIR=$PdrDraftsDir; PRD_FILE=$PrdFile; next_pdr=$nextPdr; pdr_count=$pdrCount } | ConvertTo-Json)
 } else {
   Write-Output "[INFO] product-specify setup"
   Write-Output "  REPO_ROOT: $RepoRoot"

--- a/skills/sdd-docs/SKILL.md
+++ b/skills/sdd-docs/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: sdd-docs-publish
+description: Publish externally-stored SDD docs (PDRs, PRDs, ADRs, ADs, eval artifacts, CDRs, mission state) to a git remote via draft PR. Triggered explicitly by the user; no other skill invokes it automatically.
+disable-model-invocation: true
+---
+
+# sdd-docs-publish
+
+## What this skill does
+
+Publishes SDD docs from an external `sdd_docs_location` to a git remote by creating a branch, committing the current project's subfolder, and opening a draft PR.
+
+This skill does nothing when SDD docs are stored in-project (the default). It is the only skill that performs git operations against `sdd_docs_location`.
+
+## When to use
+
+- After `product-implement`, `architect-implement`, `evals-implement`, or `mission-brief` has written SDD artifacts to an external location and you want to push them to a shared remote.
+
+### When NOT to use
+
+- `sdd_docs_location` is not configured — SDD artifacts are stored in-project and are already part of the project's own git workflow.
+- The external location's working tree has uncommitted changes you do not want to publish yet.
+
+## Process
+
+### User Input
+
+```text
+$ARGUMENTS
+```
+
+**Examples of User Input**:
+
+- `"--ready"` — Create a ready PR instead of a draft PR.
+- Empty input — Create a draft PR (default).
+
+### Flags
+
+- `--ready`: Create a ready PR instead of a draft PR.
+
+### Outline
+
+1. **Environment Setup** (Phase 0): Resolve paths and determine whether `sdd_docs_location` is configured.
+2. **Git Readiness Check** (Phase 1): Verify the external location is a git repo and the working tree is clean.
+3. **Publish** (Phase 2): Invoke the shared `git_publish_workflow()` against the current project's subfolder.
+4. **Summary** (Phase 3): Report the outcome (draft PR, ready PR, push-only, local-only, or git-init offer).
+
+### Execution Steps
+
+#### Phase 0: Environment Setup
+
+Run:
+
+```bash
+scripts/bash/setup-sdd-docs-publish.sh --json
+```
+
+Parse JSON for `REPO_ROOT`, `SDD_DOCS_LOCATION`, `SDD_ROOT`, `PROJECT_SUBFOLDER`, `SDD_CONFIGURED`, `SDD_IS_GIT`, `SDD_CLEAN`.
+
+PowerShell equivalent:
+
+```powershell
+scripts/powershell/Setup-SddDocsPublish.ps1 --json
+```
+
+If `SDD_CONFIGURED` is `false` (i.e. `SDD_DOCS_LOCATION` is empty), print verbatim:
+
+```text
+sdd_docs_location is not configured. Nothing to publish — SDD artifacts are
+stored in-project. Set sdd_docs_location in .adlc/init-options.json to enable
+external storage and publishing.
+```
+
+and exit 0.
+
+#### Phase 1: Git Readiness Check
+
+If `SDD_IS_GIT` is `false`, proceed to Phase 3 with outcome `git_init_offered`.
+
+If `SDD_CLEAN` is `false`, report:
+
+```text
+sdd_docs_location has uncommitted changes.
+Please commit or stash changes before running /sdd-docs-publish.
+```
+
+#### Phase 2: Invoke `git_publish_workflow()`
+
+Source shared helpers and call the reusable publish workflow, scoping the commit to the current project's subfolder:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEAM_HELPERS=""
+for candidate in \
+  "${SCRIPT_DIR}/../../team/team-helpers.sh" \
+  "${SCRIPT_DIR}/../team-helpers.sh" \
+  "${SCRIPT_DIR}/team-helpers.sh"; do
+  [[ -f "$candidate" ]] && { TEAM_HELPERS="$candidate"; break; }
+done
+[[ -n "$TEAM_HELPERS" ]] && source "$TEAM_HELPERS"
+
+READY_FLAG=""  # set to "--ready" if user passed --ready
+COMMIT_MSG="Publish SDD docs from ${PROJECT_SUBFOLDER}
+
+$(git -C "$SDD_DOCS_LOCATION" status --porcelain -- "$PROJECT_SUBFOLDER")
+"
+
+git_publish_workflow "$SDD_DOCS_LOCATION" "sdd-docs" "$COMMIT_MSG" "$READY_FLAG"
+```
+
+PowerShell equivalent:
+
+```powershell
+$ReadyFlag = $false  # set to $true if user passed --ready
+$Status = git -C "$env:SDD_DOCS_LOCATION" status --porcelain -- "$env:PROJECT_SUBFOLDER"
+$CommitMsg = "Publish SDD docs from ${env:PROJECT_SUBFOLDER}`n`n$Status"
+Invoke-GitPublishWorkflow -TargetDir "$env:SDD_DOCS_LOCATION" -BranchPrefix "sdd-docs" -CommitMsg $CommitMsg -Ready:$ReadyFlag
+```
+
+#### Phase 3: Report outcome
+
+Echo the `PUBLISH_OUTCOME` returned by `git_publish_workflow()`:
+
+- `draft_pr` — Draft PR created; include `PR_URL`.
+- `ready_pr` — Ready PR created; include `PR_URL`.
+- `push_only` — Pushed to remote but `gh` CLI is unavailable; prompt user to open PR manually.
+- `local_only` — Committed to a local branch; prompt user to add a remote and push.
+- `git_init_offered` — `sdd_docs_location` is not a git repo; offer `git init` + commit or write-only/no-op.
+
+## Key Rules
+
+- Publishing is not automatic — `product-implement`, `architect-implement`, `evals-implement`, and `mission-brief` never invoke git operations against `sdd_docs_location`.
+- The commit is scoped to the current project's subfolder so a multi-project external location does not produce a misleading "everything changed" message.
+- If `sdd_docs_location` is not configured, this skill exits cleanly without doing anything.
+
+## Verification
+
+- With `sdd_docs_location` unset, the setup script emits `"SDD_CONFIGURED": false` and the skill exits with the "not configured" message.
+- With `sdd_docs_location` set to a scratch external directory, the setup script emits `"SDD_CONFIGURED": true` and a correct `SDD_ROOT`/`PROJECT_SUBFOLDER`.
+- Running from two `git worktree add` checkouts of the same repo produces the same `PROJECT_SUBFOLDER`.
+
+## Context
+
+$ARGUMENTS

--- a/skills/sdd-docs/scripts/bash/setup-sdd-docs-publish.sh
+++ b/skills/sdd-docs/scripts/bash/setup-sdd-docs-publish.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# setup-evals-init.sh — Setup for evals-init (self-contained)
+# setup-sdd-docs-publish.sh — Setup for sdd-docs-publish (self-contained)
 set -euo pipefail
+
+JSON_MODE=false
+for arg in "$@"; do
+  case "$arg" in --json) JSON_MODE=true ;; esac
+done
 
 resolve_project_root() {
   local dir
@@ -13,24 +18,6 @@ resolve_project_root() {
     dir="$(dirname "$dir")"
   done
   git rev-parse --show-toplevel 2>/dev/null || pwd
-}
-
-resolve_team_ai_directives() {
-  local project_root="$1"
-  local td="${TEAM_AI_DIRECTIVES:-}"
-  [[ -n "$td" ]] && { echo "$td"; return; }
-  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
-    td=$(python3 -c "
-import json
-try:
-    with open('${project_root}/.adlc/init-options.json') as f:
-        print(json.load(f).get('team_ai_directives', ''))
-except Exception:
-    print('')
-" 2>/dev/null || true)
-    [[ -n "$td" ]] && { echo "$td"; return; }
-  fi
-  echo "${project_root}/team-ai-directives"
 }
 
 resolve_sdd_docs_location() {
@@ -61,28 +48,37 @@ sdd_project_subfolder_name() {
   fi
 }
 
-resolve_branch() {
-  git branch --show-current 2>/dev/null || echo "unknown"
-}
-
 PROJECT_ROOT=$(resolve_project_root)
-TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
 SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+PROJECT_SUBFOLDER=$(sdd_project_subfolder_name "$PROJECT_ROOT")
+
 if [[ -n "$SDD_DOCS_LOCATION" ]]; then
   SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"
-  SDD_ROOT="${SDD_DOCS_LOCATION%/}/$(sdd_project_subfolder_name "$PROJECT_ROOT")"
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/${PROJECT_SUBFOLDER}"
+  SDD_CONFIGURED="true"
 else
   SDD_ROOT="$PROJECT_ROOT"
+  SDD_CONFIGURED="false"
 fi
-BRANCH=$(resolve_branch)
 
-python3 - "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION" "$SDD_ROOT" << 'PY'
+SDD_IS_GIT="false"
+SDD_CLEAN="false"
+if [[ "$SDD_CONFIGURED" == "true" ]]; then
+  if git -C "$SDD_DOCS_LOCATION" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    SDD_IS_GIT="true"
+    SDD_CLEAN=$([[ -z "$(git -C "$SDD_DOCS_LOCATION" status --porcelain 2>/dev/null)" ]] && echo "true" || echo "false")
+  fi
+fi
+
+python3 - "$PROJECT_ROOT" "$SDD_DOCS_LOCATION" "$SDD_ROOT" "$PROJECT_SUBFOLDER" "$SDD_CONFIGURED" "$SDD_IS_GIT" "$SDD_CLEAN" <<'PY'
 import json, sys
 print(json.dumps({
   "REPO_ROOT": sys.argv[1],
-  "TEAM_AI_DIRECTIVES": sys.argv[2],
-  "BRANCH": sys.argv[3],
-  "SDD_DOCS_LOCATION": sys.argv[4],
-  "SDD_ROOT": sys.argv[5]
+  "SDD_DOCS_LOCATION": sys.argv[2],
+  "SDD_ROOT": sys.argv[3],
+  "PROJECT_SUBFOLDER": sys.argv[4],
+  "SDD_CONFIGURED": sys.argv[5] == "true",
+  "SDD_IS_GIT": sys.argv[6] == "true",
+  "SDD_CLEAN": sys.argv[7] == "true"
 }))
 PY

--- a/skills/sdd-docs/scripts/powershell/Setup-SddDocsPublish.ps1
+++ b/skills/sdd-docs/scripts/powershell/Setup-SddDocsPublish.ps1
@@ -1,0 +1,84 @@
+#!/usr/bin/env pwsh
+# Setup-SddDocsPublish.ps1 — Setup for sdd-docs-publish (self-contained)
+$ErrorActionPreference = "Stop"
+
+$JsonMode = $false
+foreach ($arg in $args) {
+  if ($arg -eq "--json") { $JsonMode = $true }
+}
+
+function Resolve-ProjectRoot {
+  $dir = (Get-Location).Path
+  while ($dir -ne "" -and $dir -ne "/") {
+    if (Test-Path (Join-Path $dir ".adlc")) { return $dir }
+    $parent = Split-Path $dir -Parent
+    if ($parent -eq $dir) { break }
+    $dir = $parent
+  }
+  $gitRoot = git rev-parse --show-toplevel 2>$null
+  if ($gitRoot) { return $gitRoot }
+  return (Get-Location).Path
+}
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot)
+  $loc = $env:SDD_DOCS_LOCATION
+  if ($loc) { return $loc }
+  $initOpts = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $initOpts) {
+    try {
+      $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+      if ($config.sdd_docs_location) { return $config.sdd_docs_location }
+    } catch {}
+  }
+  return ""
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot)
+  try {
+    $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+    if ($commonDir) {
+      return Split-Path (Resolve-Path (Join-Path (Split-Path $commonDir -Parent) .) -ErrorAction SilentlyContinue).Path -Leaf
+    }
+  } catch {}
+  return Split-Path $ProjectRoot -Leaf
+}
+
+$ProjectRoot = Resolve-ProjectRoot
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+$ProjectSubfolder = Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot
+
+if ($SddDocsLocation) {
+  if ($SddDocsLocation.StartsWith("~")) {
+    $SddDocsLocation = Join-Path $env:HOME $SddDocsLocation.Substring(1).TrimStart("/", "\")
+  }
+  $SddRoot = Join-Path $SddDocsLocation.TrimEnd("/", "\") $ProjectSubfolder
+  $SddConfigured = "true"
+} else {
+  $SddRoot = $ProjectRoot
+  $SddConfigured = "false"
+}
+
+$SddIsGit = "false"
+$SddClean = "false"
+if ($SddConfigured -eq "true") {
+  $gitCheck = git -C $SddDocsLocation rev-parse --is-inside-work-tree 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    $SddIsGit = "true"
+    $status = git -C $SddDocsLocation status --porcelain 2>$null
+    if (-not $status) { $SddClean = "true" }
+  }
+}
+
+$result = @{
+  REPO_ROOT = $ProjectRoot
+  SDD_DOCS_LOCATION = $SddDocsLocation
+  SDD_ROOT = $SddRoot
+  PROJECT_SUBFOLDER = $ProjectSubfolder
+  SDD_CONFIGURED = ($SddConfigured -eq "true")
+  SDD_IS_GIT = ($SddIsGit -eq "true")
+  SDD_CLEAN = ($SddClean -eq "true")
+}
+
+$result | ConvertTo-Json -Compress

--- a/skills/team/team-boot/SKILL.md
+++ b/skills/team/team-boot/SKILL.md
@@ -1,40 +1,334 @@
 ---
 name: team-boot
-description: Bootstrap the session with team AI directives context (constitution, CDR index, PDR/ADR indexes, skill registry). Runs automatically at session start via the event hook.
-scripts:
-  sh: scripts/boot.sh
-  ps: scripts/boot.ps1
+description: Bootstrap the session with team-ai-directives context and project decision records (PDR/ADR indexes) before responding to any user task or question. Use when starting a new session, before any task or question, before spec workflow commands, or before making code changes.
 ---
 
 # team-boot
 
 ## Overview
 
-Assembles team AI directives context and injects it into the system prompt
-at session start. The CDR index lists all available team context modules
-with descriptors — read full module files on demand when a task matches.
+Bootstrap the session with team-ai-directives context before responding to any
+user task or question. This skill loads the team constitution, reads the
+project's decision-record indexes (PDR/ADR) for product and architecture
+awareness, and runs discovery to surface relevant rules, personas, and examples.
 
-## Event hook (automatic)
+Discovery runs on **every prompt**: `team-discover` re-matches team context to
+the current message and persists it; repeats for the same feature produce a
+delta so the agent can see what moved without re-reading the whole file.
 
-The `session_start` event hook runs `scripts/boot.sh` (POSIX) or
-`scripts/boot.ps1` (Windows), which reads `.adlc/init-options.json`,
-assembles the context block (constitution, CDR index, PDR/ADR indexes,
-skill registry), and outputs it to stdout. The plugin caches the result
-and pushes it into the system prompt on every step (idempotent — same
-cached content, no accumulation).
+You MUST invoke this skill BEFORE responding to any user task or question.
+This is not optional and applies to EVERY interaction — not just spec workflow
+commands. If you think this does not apply to your current task, read the
+Common Rationalizations table below before deciding to skip it.
 
-## Manual fallback (agents without event support)
+## When to Use
 
-1. Read `.adlc/init-options.json` from the current working directory.
-   Do NOT walk up parent directories. Do NOT use glob, find, or any
-   file-search tool to locate it.
-2. If unconfigured (missing, `null`, or path doesn't exist): invoke the
-   `team-setup` skill.
-3. If configured: read and assemble the constitution, CDR.md index table,
-   PDR/ADR indexes, and `.skills.json` into your context.
-4. The CDR index is your catalog — read full module bodies on demand
-   when a task matches a CDR descriptor.
+Invoke this skill:
 
-## Unconfigured projects
+- At the start of any new session or conversation
+- Before responding to any user task or question
+- Before any spec workflow command
+- Before making code changes
+- Before answering questions about the project
 
-Invoke `team-setup` to configure team AI directives for this project.
+Re-invocation per prompt:
+- **First prompt in a session**: run the full bootstrap (Steps 1–5).
+- **Every subsequent prompt**: skip re-reading the constitution and
+  PDR/ADR indexes (Steps 1–3) if already loaded this session, but ALWAYS
+  perform Step 4 (Run Discovery) so the agent works with context matched to
+  the current prompt, then briefly acknowledge (Step 5).
+- **Unconfigured team AI directives**: Step 1 invokes the `team-setup`
+  skill on the first prompt of the session (build mode) so the project
+  self-installs. If the user declines or the session is plan/read-only,
+  Step 1 defers with the `/team-setup` guidance and Steps 2-5 (constitution,
+  indexes, discovery, acknowledgment) are skipped. The decline is remembered
+  for the session and permanently when the user opts out via the
+  `team_ai_directives: null` marker. A declined/opted-out project does not
+  re-invoke `team-setup` on subsequent prompts.
+
+## Core Process
+
+### Step 1: Locate Team AI Directives
+
+Read the file `.adlc/init-options.json` directly from the current working directory. Do NOT walk up parent directories. Do NOT use glob, find, or any file-search tool to locate it — search tools may silently skip dotfile-prefixed path segments. Read the file at the exact relative path `.adlc/init-options.json` from the current working directory.
+
+From the JSON, extract the `team_ai_directives` field. Its state drives a
+three-way branch:
+
+- **Configured** (`team_ai_directives` is a non-null string and the path
+  exists): use it as the team AI directives root and proceed to Steps 2-5.
+- **Declined** (file exists but `team_ai_directives` is `null` or the file
+  contains `"team_setup": "declined"`): the user opted out of setup for
+  this project. Skip setup silently on every prompt — do NOT invoke
+  `team-setup`, do NOT output guidance. Answer the user's task using only
+  `AGENTS.md` and project-level context.
+- **Unconfigured** (file missing, field missing, or path doesn't exist):
+  team AI directives are unconfigured. **Self-install (MANDATORY in build mode)**:
+  invoke the `team-setup` skill immediately (`skill({ name: "team-setup" })`)
+  so the project can wire itself. Do NOT second-guess this invocation because
+  the user's prompt is a question, because you think `team-setup` is noisy or
+  intrusive, or because you believe the working directory is a "meta repo" or
+  "skills repo" — self-install is non-negotiable in build mode. In
+  plan/read-only mode, do NOT invoke `team-setup` (its writes would be
+  blocked) — instead output the following guidance message, defer setup to
+  a build-mode prompt, and proceed with the user's task using only
+  `AGENTS.md` and project-level context.
+  ```text
+  Team AI directives not configured.
+  Run /team-setup to:
+    1. Clone, point to, or scaffold a team AI directives repository
+    2. Write .adlc/init-options.json
+    3. Inject the AGENTS.md team-boot directive
+    4. Install domain skills from .skills.json
+    5. Install MCP servers from .mcp.json
+  ```
+  After `team-setup` returns:
+  - **Configured**: continue to Steps 2-5.
+  - **Declined by the user**: offer the persistent opt-out (writes
+    `team_ai_directives: null`, build mode only); remember the decline for
+    the rest of this session and do NOT re-invoke `team-setup` on
+    subsequent prompts. Proceed with the user's task using only `AGENTS.md`
+    and project-level context.
+  - **Plan/read-only mode**: remember the deferral for the rest of this
+    session and do NOT re-invoke `team-setup` on subsequent prompts.
+
+In subsequent steps, `{TEAM_AI_DIRECTIVES}` refers to this value, resolved
+as a path relative to the current working directory. Read files at this
+path directly — do NOT use glob, find, or any file-search tool to locate
+them.
+
+Add an explicit resolution step (before Step 2) that computes `PROJECT_ROOT`,
+`SDD_DOCS_LOCATION`, `SDD_ROOT`, and `PROJECT_SUBFOLDER`. You may source
+`skills/team/team-helpers.sh` and call its helpers, or use this equivalent
+inline bash:
+
+```bash
+PROJECT_ROOT="$(pwd)"
+
+resolve_sdd_docs_location() {
+  local sdd_docs_location=""
+  if [[ -n "${SDD_DOCS_LOCATION:-}" ]]; then
+    sdd_docs_location="$SDD_DOCS_LOCATION"
+  else
+    local init_options="${PROJECT_ROOT}/.adlc/init-options.json"
+    if [[ -f "$init_options" ]]; then
+      sdd_docs_location=$(python3 -c "
+import json
+try:
+    with open('$init_options') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+    fi
+  fi
+  echo "$sdd_docs_location"
+}
+
+sdd_project_subfolder_name() {
+  local common_dir
+  common_dir=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$PROJECT_ROOT"
+  fi
+}
+
+SDD_DOCS_LOCATION=$(resolve_sdd_docs_location)
+if [[ -n "$SDD_DOCS_LOCATION" ]]; then
+  SDD_DOCS_LOCATION="${SDD_DOCS_LOCATION/#\~/$HOME}"  # expand tilde
+  PROJECT_SUBFOLDER=$(sdd_project_subfolder_name)
+  SDD_ROOT="${SDD_DOCS_LOCATION%/}/${PROJECT_SUBFOLDER}"
+else
+  SDD_ROOT="$PROJECT_ROOT"
+fi
+```
+
+**Note**: `PROJECT_SUBFOLDER` is derived from the git common-dir's parent directory name (stable across `git worktree add` checkouts of the same repo), matching `resolve_sdd_root()` in `skills/team/team-helpers.sh` and every setup script that resolves `SDD_ROOT`. Do NOT derive it from the git remote URL — that would produce a different subfolder than the one setup scripts write to whenever the local directory name differs from the remote repo name (e.g., forks, renamed clones).
+
+**Important**: `.adlc/init-options.json` itself is read from `PROJECT_ROOT`
+(above), not from `SDD_ROOT`. Only the SDD artifact paths in Step 3 use
+`SDD_ROOT`.
+
+### Step 2: Load Team Constitution
+
+Using the `team_ai_directives` value from Step 1, read
+`{TEAM_AI_DIRECTIVES}/context_modules/constitution.md` directly. Construct
+the path from the value resolved in Step 1 and read the file — do NOT use
+glob, find, or any file-search tool to locate it.
+
+Read the constitution in full.
+
+The team constitution is the foundational principles document. It governs
+agent behavior and team interactions. Internalize its principles before
+proceeding — they apply to every task you will work on in this session.
+
+### Step 3: Load Product & Architecture Context
+
+Load the project's decision-record **indexes** for awareness-level product and
+architecture context. Indexes are small tables — read them in full. Do NOT read
+full `PRD.md`, `AD.md`, or individual PDR/ADR bodies during boot; those are
+pulled on demand by `team-discover` and the product/architect skills.
+
+`{SDD_ROOT}` is the project root (where `.adlc/` lives), or the external
+`sdd_docs_location` subfolder if configured.
+
+**PDR index** (product decisions):
+
+1. Read `{SDD_ROOT}/.adlc/memory/pdr/pdr.md` (accepted PDRs) directly.
+2. If missing but `{SDD_ROOT}/PRD.md` exists (legacy/monolithic
+   project without PDRs), skim `PRD.md` at heading level: read the headings
+   plus overview/mission/requirements sections only. Skip mermaid blocks,
+   diagrams, and appendices.
+
+**ADR index** (architecture decisions):
+
+1. Read `{SDD_ROOT}/.adlc/memory/adr/adr.md` (accepted ADRs) directly.
+2. If missing, skip — ADR index is absent.
+
+**Presence notes**: If `{SDD_ROOT}/PRD.md` or `{SDD_ROOT}/AD.md` exist, note
+their paths as deep-read pointers for architecture- or product-heavy tasks —
+without loading them.
+
+Skip silently for any artifact that does not exist. Projects without the PDR
+or ADR lifecycle in place simply produce less context here — that is fine.
+
+### Step 4: Run Discovery
+
+**Guard**: This step runs only when Step 1 resolved a valid `team_ai_directives`. If team AI directives is unconfigured, Step 1 invoked `team-setup` (or deferred in plan/read-only mode) — do NOT invoke `team-discover`; discovery has no directives to search.
+
+Invoke the `team-discover` skill on **every prompt** — specify, plan,
+implement, question, debugging, or chat. Discovery re-matches team context to
+the current message. In build mode it persists results to
+`.adlc/drafts/team-context.md` (same feature → delta-aware overwrite; different
+feature → reset); in plan mode / read-only phases it outputs the table inline
+only (no file writes).
+
+Do **not** decide the prompt is a "continuation" and skip discovery. The
+follow-up "fix the help message" is a different task surface than "add help
+modal" and may surface different rules (accessibility, testing). There is no
+prompt-type gate and no continuation exemption — every prompt re-runs
+discovery. When the prompt is a pure acknowledgment with no task content
+("ok", "thanks"), the run is still cheap: the delta will show "no changes".
+
+Extract domain, technology, patterns, and actions from the user's request to
+drive discovery matching, then invoke `team-discover`.
+
+`team-discover` returns a **Discovered Team Context** table and a
+`search_metadata` line. These are Step 4's output — Step 5 surfaces them.
+
+### Step 5: Acknowledge Context (Output Contract)
+
+After loading the constitution and the decision-record indexes and running
+discovery (Step 4), surface the bootstrap result in the **visible response**
+(not only in reasoning/thinking). This confirms the bootstrap completed and
+makes the skill check verifiable.
+
+**Output contract** — the visible response MUST contain, before the task
+response:
+
+- Constitution: loaded (or skipped)
+- PDR index: N entries (memory | legacy PRD skim | none)
+- ADR index: N entries (memory | drafts | none)
+- **The `team-discover` table** (Discovered Team Context: ID / Module / Type /
+  Descriptor / Relevance) **and the `search_metadata` line**, produced this
+  prompt. If discovery found no matches, the table is empty but the
+  `search_metadata` line still appears (e.g. `_Searched 0 CDR entries …_`).
+
+If the discovery table or `search_metadata` is absent from the visible
+response, discovery did not actually run — go back and execute `team-discover`
+before proceeding. Loading a SKILL.md without producing its output table is a
+failed Step 4, not a completed one.
+
+### Failure Handling
+
+If `.adlc/init-options.json` or team-ai-directives is not configured, or files cannot be read:
+1. In build mode, invoke the `team-setup` skill so the project can self-install. In plan/read-only mode, output the `Team AI directives not configured` guidance message and defer setup.
+2. If the user declines setup (or in plan/read-only mode), stop the bootstrap here — do NOT invoke `team-discover` (Step 4 is guarded on configuration).
+3. Proceed with the task using only `AGENTS.md` and project-level context.
+4. Exit successfully (the bootstrap is best-effort).
+
+## Common Rationalizations
+
+Do NOT rationalize skipping the skill check. Every thought below is wrong:
+
+| Rationalization | Reality |
+|---|---|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "Plan mode / read-only phase forbids modifications" | The `skill` tool is read-only; it never conflicts with plan mode. |
+| "I need to be efficient / focus on the task" | Efficiency is not a skip reason. The check is the first step. |
+| "The task matters more than the check" | The check IS part of the task. |
+| "The user can run /team-setup themselves" | When unconfigured, team-boot invokes `team-setup` so the project self-installs; deferring manual setup leaves directives invisible. |
+| "The user asked a question/consultation, so invoking `team-setup` is intrusive" | Self-install is mandatory in build mode regardless of prompt type. Invoke `team-setup` first, then answer the question. |
+| "This repository is a skills/meta repo so `team-setup` doesn't apply" | `team-setup` applies to ALL unconfigured repositories without exception. |
+| "I should be pragmatic and output guidance instead of invoking `team-setup`" | Skipping `team-setup` in build mode is a rule violation, not pragmatism. |
+
+## Red Flags
+
+- Responding to a user task without having read the team constitution first.
+- First tool call in a session being anything other than `skill({name: "team-boot"})`. Mechanically verifiable in any trace.
+- Fabricating a conflict between plan mode / read-only phase and the skill check. The `skill` tool is read-only and never forbidden by plan mode.
+- Using glob/find or any file-search tool to locate `.adlc/init-options.json`
+  instead of reading the exact relative path directly.
+- Reading full `PRD.md`, `AD.md`, or individual PDR/ADR bodies during boot
+  when the `pdr.md`/`adr.md` indexes exist — indexes are the awareness layer;
+  bodies load on demand.
+- Skipping discovery because the request "seems simple" or "obvious."
+- Proceeding to answer without acknowledging what team context was loaded.
+- Skipping discovery on any prompt — there is no continuation exemption and no spec/plan gate; every prompt re-runs `team-discover` so context matches the current message.
+- Treating a follow-up like "fix the help message" as a continuation and skipping discovery — it is a new task surface and may surface different rules.
+- Re-reading the constitution and PDR/ADR indexes on every follow-up prompt — once loaded in the session, skip Steps 1–3 and go straight to Step 4.
+- Invoking `team-discover` when `.adlc/init-options.json` is missing / team AI directives is unconfigured — Step 1 invoked `team-setup` (or deferred); discovery has no directives to search.
+- Re-invoking `team-setup` on subsequent prompts when the user already declined this session, or when the `team_ai_directives: null` opt-out marker is present — respect the session-scoped decline and the persistent marker; proceed with project context instead.
+- Invoking `team-setup` in plan mode / read-only phase — its writes would be blocked; output the `/team-setup` guidance and defer instead.
+- Second-guessing or skipping the `team-setup` invocation in build mode because the user's prompt is a question, conversation, or consultation.
+- Rationalizing that a working directory is a "meta repo", "skills repo", or "special case" where `team-setup` self-install should be skipped in build mode.
+- Producing a Step 5 acknowledgment that references no discovery table / `search_metadata` — that means `team-discover` was loaded but not executed.
+- Persisting `team-context.md` in plan mode / read-only phase — `team-discover` must run inline (no-write) there.
+
+## Verification
+
+The bootstrap is complete when ALL of the following are true:
+
+1. `.adlc/init-options.json` was read directly from the current working
+   directory (no parent-directory walk-up) and the `team_ai_directives` field
+   was extracted. Configured → Steps 2-5 ran. Declined (`null` marker) →
+   silent project-context path. Unconfigured → `team-setup` was invoked
+   (build mode) or the `/team-setup` guidance was output and the bootstrap
+   exited early before Steps 2-5.
+2. The constitution at `{TEAM_AI_DIRECTIVES}/context_modules/constitution.md`
+   was read in full (skipped when unconfigured).
+3. The PDR index was read if present (memory or legacy `PRD.md` heading
+   skim), and the ADR index was read if present (memory only). Full PDR/ADR
+   bodies and full `PRD.md`/`AD.md` were NOT loaded.
+4. When team AI directives are configured, Step 4 was performed on every
+   prompt: `team-discover` was invoked **and executed** (Discovered Team
+   Context table + `search_metadata` produced) with domain, technology,
+   patterns, and actions extracted from the user's request. On follow-up
+   prompts in the same session, Steps 1–3 re-reads were skipped but Step 4
+   still ran — no continuation exemption. When unconfigured, discovery was
+   correctly NOT run (Step 1 invoked `team-setup` or deferred) and
+   `team-discover` was never invoked.
+5. The loaded team context (constitution, indexes, discovery matches) was
+   surfaced in the **visible response** before the task response — including
+   the `team-discover` table and `search_metadata` line (the output contract).
+   When unconfigured, the visible response shows the setup handover — the
+   `team-setup` invocation (build mode) or the `/team-setup` guidance
+   (plan/read-only or declined) — instead of a discovery table.
+6. The skill exited successfully (best-effort) even if team-ai-directives is
+   unconfigured or files cannot be read — answering the user's task from
+   `AGENTS.md` and project-level context only.
+
+## Configuration
+
+- `TEAM_AI_DIRECTIVES` — Path to the team AI directives (overrides `.adlc/init-options.json`).
+- `.adlc/init-options.json` — Project-level config file, read directly from the current working directory. `team_ai_directives` set to a path = configured; `team_ai_directives: null` (or `"team_setup": "declined"`) = user opted out (silent skip); file/field missing or path invalid = unconfigured (invoke `team-setup`).
+
+## 12-Factor Alignment
+
+Factor XI (Directives as Code) — ensures team directives are loaded before any task.

--- a/skills/team/team-helpers.ps1
+++ b/skills/team/team-helpers.ps1
@@ -1,0 +1,522 @@
+#!/usr/bin/env pwsh
+# team-helpers.ps1 — Shared utilities for team-* skills (PowerShell)
+#
+# Flags:
+#   -Json              Output path info as JSON (default: key=value)
+#   -Scaffold DIR      Create a fresh 11-file team AI directives scaffold at DIR
+#   -AgentsOnly DIR    Create only AGENTS.md at DIR (for repair use)
+#   -InjectAgents DIR  Inject team-boot directive into project-level AGENTS.md at DIR
+#   -Name NAME         Team name for scaffold (default: "My Team")
+#
+# Library functions (sourced by other skills' setup scripts, not CLI flags):
+#   Resolve-SddDocsLocation, Get-SddProjectSubfolderName, Invoke-GitPublishWorkflow
+param(
+  [switch]$Json,
+  [string]$Scaffold = "",
+  [string]$AgentsOnly = "",
+  [string]$InjectAgents = "",
+  [string]$Name = "My Team"
+)
+
+$ErrorActionPreference = "Stop"
+
+# 1. PATH RESOLUTION
+$ProjectRoot = if ($env:PROJECT_ROOT) { $env:PROJECT_ROOT } else {
+  $gitRoot = git rev-parse --show-toplevel 2>$null
+  if ($gitRoot) { $gitRoot } else { (Get-Location).Path }
+}
+
+$Branch = if ($env:BRANCH) { $env:BRANCH } else {
+  $b = git branch --show-current 2>$null
+  if ($b) { $b } else { "unknown" }
+}
+
+$TeamAiDirectives = ""
+
+# 1. Check TEAM_AI_DIRECTIVES env var (highest priority)
+if ($env:TEAM_AI_DIRECTIVES) {
+  $TeamAiDirectives = $env:TEAM_AI_DIRECTIVES
+}
+
+# 2. Check .adlc/init-options.json
+if (-not $TeamAiDirectives) {
+  $InitOptions = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $InitOptions) {
+    try {
+      $Config = Get-Content $InitOptions -Raw | ConvertFrom-Json
+      if ($Config.team_ai_directives) {
+        $TeamAiDirectives = $Config.team_ai_directives
+      }
+    } catch {}
+  }
+}
+
+# 3. Fallback to default path
+if (-not $TeamAiDirectives) {
+  $TeamAiDirectives = Join-Path $ProjectRoot "team-ai-directives"
+}
+
+function Write-OutputKeyValue {
+  param([string]$SddDocsLocation = "")
+  Write-Output "PROJECT_ROOT=$ProjectRoot"
+  Write-Output "TEAM_AI_DIRECTIVES=$TeamAiDirectives"
+  Write-Output "BRANCH=$Branch"
+  Write-Output "SDD_DOCS_LOCATION=$SddDocsLocation"
+}
+
+function Write-OutputJson {
+  param([string]$SddDocsLocation = "")
+  $output = @{
+    REPO_ROOT = $ProjectRoot
+    TEAM_AI_DIRECTIVES = $TeamAiDirectives
+    BRANCH = $Branch
+    SDD_DOCS_LOCATION = $SddDocsLocation
+  }
+  return $output | ConvertTo-Json
+}
+
+function Resolve-SddDocsLocation {
+  param([string]$ProjectRoot = $ProjectRoot)
+  $sddDocsLocation = ""
+
+  # 1. Environment variable (highest priority)
+  if ($env:SDD_DOCS_LOCATION) {
+    $sddDocsLocation = $env:SDD_DOCS_LOCATION
+  }
+
+  # 2. .adlc/init-options.json
+  if (-not $sddDocsLocation) {
+    $initOptions = Join-Path $ProjectRoot ".adlc" "init-options.json"
+    if (Test-Path $initOptions) {
+      try {
+        $config = Get-Content $initOptions -Raw | ConvertFrom-Json
+        if ($config.sdd_docs_location) {
+          $sddDocsLocation = $config.sdd_docs_location
+        }
+      } catch {}
+    }
+  }
+
+  # 3. Default empty (project root)
+  return $sddDocsLocation
+}
+
+function Get-SddProjectSubfolderName {
+  param([string]$ProjectRoot = $ProjectRoot)
+  $commonDir = $null
+  try {
+    $commonDir = git -C $ProjectRoot rev-parse --git-common-dir 2>$null
+  } catch {}
+  if ($commonDir) {
+    return (Split-Path (Resolve-Path (Join-Path $commonDir "..")).Path -Leaf)
+  }
+  return (Split-Path $ProjectRoot -Leaf)
+}
+
+function Resolve-SddRoot {
+  param([string]$ProjectRoot = $ProjectRoot)
+  $sddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+
+  if ($sddDocsLocation) {
+    # Expand tilde to $HOME
+    if ($sddDocsLocation.StartsWith("~")) {
+      $sddDocsLocation = Join-Path $env:HOME $sddDocsLocation.Substring(1).TrimStart("/", "\")
+    }
+    $projectSubfolder = Get-SddProjectSubfolderName -ProjectRoot $ProjectRoot
+    return (Join-Path $sddDocsLocation.TrimEnd("/", "\") $projectSubfolder)
+  } else {
+    return $ProjectRoot
+  }
+}
+
+# 2. TEAM AI DIRECTIVES STRUCTURE VALIDATION
+function Test-TeamAiDirectivesStructure {
+  param([string]$Dir)
+  $missing = 0
+  $required = @(
+    "context_modules/constitution.md",
+    "context_modules/rules",
+    "context_modules/personas",
+    "context_modules/examples",
+    "CDR.md",
+    ".skills.json"
+  )
+  foreach ($item in $required) {
+    $path = Join-Path $Dir $item
+    if (-not (Test-Path $path)) {
+      Write-Output "MISSING: $item"
+      $missing++
+    }
+  }
+  return $missing
+}
+
+# 3. SCAFFOLD
+function New-TeamAiDirectivesScaffold {
+  param([string]$Dest, [string]$TeamName = "My Team")
+  $today = Get-Date -Format "yyyy-MM-dd"
+
+  if ((Test-Path $Dest) -and (Get-ChildItem $Dest -Force).Count -gt 0) {
+    Write-Error "Destination '$Dest' already exists and is not empty."
+    exit 1
+  }
+
+  $null = New-Item -ItemType Directory -Force -Path (Join-Path $Dest "context_modules/rules")
+  $null = New-Item -ItemType Directory -Force -Path (Join-Path $Dest "context_modules/personas")
+  $null = New-Item -ItemType Directory -Force -Path (Join-Path $Dest "context_modules/examples")
+  $null = New-Item -ItemType Directory -Force -Path (Join-Path $Dest "skills")
+
+  $readme = @"
+# ${TeamName} Team AI Directives
+
+Team AI directives repository for ${TeamName}.
+
+## Getting Started
+
+1. Wire this directives repository into a project:
+   ```
+   /team-setup
+   ```
+   Choose "Point to existing local path" and select this directory.
+
+2. Add context modules to `context_modules/` (rules, personas, examples).
+
+3. Add skills to `skills/` and register them in `.skills.json`.
+
+4. Update `CDR.md` as context modules are approved.
+
+See [ADLC Team Skills](https://github.com/tikalk/adlc-team-skills) for full documentation.
+"@
+  Set-Content -Path (Join-Path $Dest "README.md") -Value $readme
+
+  $agents = @'
+# Agent Instructions
+
+## Structure
+
+- `context_modules/constitution.md` — Team constitution
+- `context_modules/rules/` — Team rules and workflows
+- `context_modules/personas/` — Team personas
+- `context_modules/examples/` — Team examples
+- `skills/` — Team skills
+- `evals/` — Directive compliance goldensets (pass/fail cases)
+- `CDR.md` — Context Directive Records
+
+## Loading Order
+
+1. Load constitution.md first
+2. Load relevant rules for the current task
+3. Load relevant personas for the current task
+4. Load relevant examples for the current task
+
+## Using Skills
+
+Skills are located in the `skills/` directory. Browse available skills using team-skills and install them as needed.
+
+## CDR.md
+
+The CDR.md file tracks approved context contributions. Update it when adding new context modules.
+'@
+  Set-Content -Path (Join-Path $Dest "AGENTS.md") -Value $agents
+
+  $cdr = @"
+# Context Directive Records
+
+Context Directive Records (CDRs) track decisions about contributing context modules (rules, personas, examples, skills) to team-ai-directives.
+
+## CDR Index
+
+| ID | Target Module | Type | Status | Created | Verified | Age | Descriptor |
+|----|---------------|------|--------|---------|----------|-----|------------|
+
+**Stats**: 0 entries | Last Updated: ${today}
+"@
+  Set-Content -Path (Join-Path $Dest "CDR.md") -Value $cdr
+
+  $skillsJson = @'
+{
+  "version": "2.0.0",
+  "source": "team-ai-directives",
+  "description": "Team skills manifest. The `default` list contains skill names that are auto-installed during project setup. The `external` map contains on-demand skills fetched by URL. The `blocked` list contains skills that must never be installed.",
+  "default": [],
+  "external": {},
+  "blocked": [],
+  "policy": {
+    "auto_install_default": true,
+    "enforce_blocked": true,
+    "allow_project_override": true
+  }
+}
+'@
+  Set-Content -Path (Join-Path $Dest ".skills.json") -Value $skillsJson
+
+  $mcpJson = @'
+{
+  "mcpServers": {}
+}
+'@
+  Set-Content -Path (Join-Path $Dest ".mcp.json.example") -Value $mcpJson
+
+  $constitution = @"
+---
+type: Constitution
+title: "${TeamName} Constitution"
+description: "Team-wide principles and governance"
+resource: ./context_modules/constitution.md
+tags: [constitution]
+timestamp: ${today}T00:00:00Z
+---
+
+# ${TeamName} Constitution
+
+No team-wide principles defined yet. Add principles as they are established.
+"@
+  Set-Content -Path (Join-Path $Dest "context_modules/constitution.md") -Value $constitution
+
+  $indexTop = @"
+# Context Modules
+
+| Directory | Description |
+|-----------|-------------|
+| [rules/](rules/index.md) | Team rules and workflows |
+| [personas/](personas/index.md) | Team personas |
+| [examples/](examples/index.md) | Team examples |
+"@
+  Set-Content -Path (Join-Path $Dest "context_modules/index.md") -Value $indexTop
+
+  Set-Content -Path (Join-Path $Dest "context_modules/rules/index.md") -Value "# Rules`n`nNo rules defined yet. Use /levelup-specify to create rules via CDRs."
+  Set-Content -Path (Join-Path $Dest "context_modules/personas/index.md") -Value "# Personas`n`nNo personas defined yet. Use /levelup-specify to create personas via CDRs."
+  Set-Content -Path (Join-Path $Dest "context_modules/examples/index.md") -Value "# Examples`n`nNo examples defined yet. Use /levelup-specify to create examples via CDRs."
+
+  $null = New-Item -ItemType File -Force -Path (Join-Path $Dest "context_modules/rules/.gitkeep")
+  $null = New-Item -ItemType File -Force -Path (Join-Path $Dest "context_modules/personas/.gitkeep")
+  $null = New-Item -ItemType File -Force -Path (Join-Path $Dest "context_modules/examples/.gitkeep")
+  $null = New-Item -ItemType File -Force -Path (Join-Path $Dest "skills/.gitkeep")
+
+  Write-Output "Scaffolded team-ai-directives at ${Dest}"
+  Write-Output "Team name: ${TeamName}"
+  Write-Output "Files created: 14"
+
+  $missing = Test-TeamAiDirectivesStructure -Dir $Dest
+  if ($missing -gt 0) {
+    Write-Output "WARNING: $missing required items missing"
+  }
+}
+
+function New-AgentsOnly {
+  param([string]$Dest)
+  $null = New-Item -ItemType Directory -Force -Path $Dest
+
+  $agents = @'
+# Agent Instructions
+
+## Structure
+
+- `context_modules/constitution.md` — Team constitution
+- `context_modules/rules/` — Team rules and workflows
+- `context_modules/personas/` — Team personas
+- `context_modules/examples/` — Team examples
+- `skills/` — Team skills
+- `evals/` — Directive compliance goldensets (pass/fail cases)
+- `CDR.md` — Context Directive Records
+
+## Loading Order
+
+1. Load constitution.md first
+2. Load relevant rules for the current task
+3. Load relevant personas for the current task
+4. Load relevant examples for the current task
+
+## Using Skills
+
+Skills are located in the `skills/` directory. Browse available skills using team-skills and install them as needed.
+
+## CDR.md
+
+The CDR.md file tracks approved context contributions. Update it when adding new context modules.
+'@
+  Set-Content -Path (Join-Path $Dest "AGENTS.md") -Value $agents
+  Write-Output "Created AGENTS.md at ${Dest}"
+}
+
+# 4. INJECT PROJECT-LEVEL AGENTS.md DIRECTIVE
+function Invoke-ProjectAgentsInjection {
+  param([string]$ProjectRoot = ".")
+
+  $TeamDirective = ""
+
+  # Resolve team_ai_directives from .adlc/init-options.json
+  $InitOptions = Join-Path $ProjectRoot ".adlc" "init-options.json"
+  if (Test-Path $InitOptions) {
+    try {
+      $Config = Get-Content $InitOptions -Raw | ConvertFrom-Json
+      if ($Config.team_ai_directives) {
+        $TeamDirective = $Config.team_ai_directives
+      }
+    } catch {}
+  }
+
+  # Fallback to env var
+  if (-not $TeamDirective -and $env:TEAM_AI_DIRECTIVES) {
+    $TeamDirective = $env:TEAM_AI_DIRECTIVES
+  }
+
+  # Fallback to default path
+  if (-not $TeamDirective) {
+    $TeamDirective = Join-Path $ProjectRoot "team-ai-directives"
+  }
+
+  $AgentsFile = Join-Path $ProjectRoot "AGENTS.md"
+  $MarkerStart = "<!-- TEAM_AI_DIRECTIVES START -->"
+  $MarkerEnd = "<!-- TEAM_AI_DIRECTIVES END -->"
+
+  $Section = @"
+$MarkerStart
+## Team Directives & Constitution
+
+This project is bound by the team AI directives repository at ``$TeamDirective``.
+- **Strict Compliance**: You MUST invoke the ``team-boot`` skill BEFORE responding to any task or question. This is not optional and applies to every interaction. If a skill applies, you MUST invoke it immediately.
+- **First-Tool-Call Gate**: Your FIRST tool call in any session MUST be ``skill({name: "team-boot"})``. If your first tool call is ``read``, ``grep``, ``glob``, ``bash``, or any other tool, you have VIOLATED this directive -- stop and invoke ``team-boot`` before continuing. Mechanically verifiable in any trace.
+- **Plan-Mode Compatibility**: Loading a skill is read-only -- it injects instructions, it does NOT modify files. Plan mode / read-only phase NEVER forbids the ``skill`` tool. Do not fabricate a conflict between plan mode and the skill check.
+- **Anti-Patterns** (do NOT rationalize skipping the skill check):
+  - "Let me explore the codebase first" -> Skills tell you HOW to explore. Check first.
+  - "This is a plain message, not a spec command" -> Skill check applies to EVERY interaction.
+  - "I'll check after understanding the request" -> Check BEFORE understanding -- skills guide your questions.
+  - "This is too simple" -> Simple things become complex. Check first.
+  - "Plan mode forbids modifications" -> The ``skill`` tool is read-only; plan mode never forbids it.
+  - "I need to be efficient / focus on the task" -> The check IS the first step, not overhead to optimize away.
+  - "The task matters more than the check" -> The check IS part of the task; skipping it is a violation.
+- **Team Constitution**: Read and strictly adhere to the principles in ``$TeamDirective/context_modules/constitution.md``. When creating or updating the project's constitution, you MUST inherit and align with these principles.
+- **Rules, Personas & Examples**: Use the ``team-discover`` skill to find and load relevant rules, personas, or examples before making changes.
+- **Tech Radar Guidance**: Use the ``tech-radar-context`` skill whenever evaluating or choosing technologies, frameworks, databases, libraries, or cloud infrastructure.
+$MarkerEnd
+"@
+
+  if (Test-Path $AgentsFile) {
+    $Content = Get-Content $AgentsFile -Raw -Encoding UTF8
+    $StartIdx = $Content.IndexOf($MarkerStart)
+    $EndIdx = $Content.IndexOf($MarkerEnd)
+
+    if ($StartIdx -ge 0 -and $EndIdx -gt $StartIdx) {
+      # Replace existing managed section
+      $NewContent = $Content.Substring(0, $StartIdx) + $Section + $Content.Substring($EndIdx + $MarkerEnd.Length)
+      if (-not $NewContent.EndsWith("`n")) { $NewContent += "`n" }
+      elseif (-not $NewContent.EndsWith("`n`n")) { $NewContent += "`n" }
+      Set-Content -Path $AgentsFile -Value $NewContent -Encoding UTF8
+      Write-Output "Updated team AI directives section in $AgentsFile"
+    } else {
+      # Append managed section
+      if ($Content -and -not $Content.EndsWith("`n")) { $Content += "`n" }
+      if ($Content -and -not $Content.EndsWith("`n`n")) { $Content += "`n" }
+      $Content += $Section + "`n"
+      Set-Content -Path $AgentsFile -Value $Content -Encoding UTF8
+      Write-Output "Injected team AI directives section into $AgentsFile"
+    }
+  } else {
+    # Create new AGENTS.md
+    Set-Content -Path $AgentsFile -Value ($Section + "`n") -Encoding UTF8
+    Write-Output "Created $AgentsFile with team AI directives section"
+  }
+}
+
+# 5. SHARED GIT PUBLISH WORKFLOW
+
+# Reusable branch/commit/push/PR decision tree extracted from levelup-publish.
+# Usage: Invoke-GitPublishWorkflow -TargetDir <path> -BranchPrefix <prefix> -CommitMsg <msg> [-Ready]
+# Emits PUBLISH_OUTCOME=<draft_pr|ready_pr|push_only|local_only|git_init_offered>
+# and PR_URL=<url> when applicable.
+function Invoke-GitPublishWorkflow {
+  param(
+    [Parameter(Mandatory = $true)][string]$TargetDir,
+    [Parameter(Mandatory = $true)][string]$BranchPrefix,
+    [Parameter(Mandatory = $true)][string]$CommitMsg,
+    [switch]$Ready
+  )
+
+  $ProjectName = Split-Path -Leaf ($env:PROJECT_ROOT -or (git rev-parse --show-toplevel 2>$null) -or (Get-Location).Path)
+  $BranchName = "$BranchPrefix/$ProjectName"
+
+  # Case D: target is not a git repository — offer git init or write-only/no-op.
+  $gitCheck = git -C $TargetDir rev-parse --is-inside-work-tree 2>$null
+  if ($LASTEXITCODE -ne 0 -or -not $gitCheck) {
+    Write-Output "PUBLISH_OUTCOME=git_init_offered"
+    Write-Output "TARGET_DIR=$TargetDir"
+    Write-Output "Target directory is not a git repository. Options:"
+    Write-Output ""
+    Write-Output "1. Initialize git and commit:"
+    Write-Output "   cd \"$TargetDir\""
+    Write-Output "   git init"
+    Write-Output "   git add -A"
+    Write-Output "   git commit -m \"Initial commit\""
+    Write-Output "   git checkout -b \"$BranchName\""
+    Write-Output ""
+    Write-Output "2. Write files only (skip git operations)."
+    return
+  }
+
+  # Create branch (use main if it exists, otherwise HEAD).
+  Push-Location $TargetDir
+  try {
+    $null = git checkout -b "$BranchName" main 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $null = git checkout -b "$BranchName"
+    }
+  } finally {
+    Pop-Location
+  }
+
+  # Commit changes if there is anything to commit.
+  $status = git -C $TargetDir status --porcelain 2>$null
+  if ($status) {
+    git -C $TargetDir add -A
+    git -C $TargetDir commit -m "$CommitMsg"
+  }
+
+  # Check for remote "origin".
+  $remoteUrl = git -C $TargetDir remote get-url origin 2>$null
+  if ($remoteUrl) {
+    git -C $TargetDir push -u origin "$BranchName"
+
+    # Case A: remote + gh CLI available.
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if ($gh) {
+      $prTitle = ($CommitMsg -split "`r?`n")[0]
+      $prBody = $CommitMsg
+      $draftFlag = if ($Ready) { @() } else { @("--draft") }
+      $prUrl = (cd $TargetDir && gh pr create @draftFlag --title "$prTitle" --body "$prBody" 2>$null) -join "`n"
+      if ($prUrl) {
+        if ($Ready) {
+          Write-Output "PUBLISH_OUTCOME=ready_pr PR_URL=$prUrl"
+        } else {
+          Write-Output "PUBLISH_OUTCOME=draft_pr PR_URL=$prUrl"
+        }
+      } else {
+        Write-Output "PUBLISH_OUTCOME=push_only"
+        Write-Output "MESSAGE=Pushed to origin/$BranchName. Open a PR manually at your Git host."
+      }
+    } else {
+      # Case B: remote exists but gh is not available.
+      Write-Output "PUBLISH_OUTCOME=push_only"
+      Write-Output "MESSAGE=Pushed to origin/$BranchName. Open a PR manually at your Git host."
+    }
+  } else {
+    # Case C: no remote exists.
+    Write-Output "PUBLISH_OUTCOME=local_only"
+    Write-Output "MESSAGE=Committed to local branch $BranchName. Add a remote (git remote add origin <url>) and push when ready."
+  }
+}
+
+# MAIN
+$SddDocsLocation = Resolve-SddDocsLocation -ProjectRoot $ProjectRoot
+
+if ($Scaffold) {
+  New-TeamAiDirectivesScaffold -Dest $Scaffold -TeamName $Name
+} elseif ($AgentsOnly) {
+  New-AgentsOnly -Dest $AgentsOnly
+} elseif ($InjectAgents -ne "") {
+  Invoke-ProjectAgentsInjection -ProjectRoot $InjectAgents
+} elseif ($Json) {
+  Write-OutputJson -SddDocsLocation $SddDocsLocation
+} else {
+  Write-OutputKeyValue -SddDocsLocation $SddDocsLocation
+}

--- a/skills/team/team-helpers.sh
+++ b/skills/team/team-helpers.sh
@@ -1,0 +1,636 @@
+#!/usr/bin/env bash
+# team-helpers.sh — Shared utilities for team-* skills
+# 
+# Flags:
+#   --json              Output path info as JSON (default: key=value)
+#   --scaffold [DIR]    Create a fresh 11-file team AI directives scaffold at DIR
+#   --agents-only DIR   Create only AGENTS.md at DIR (for repair use)
+#   --inject-agents [DIR]  Inject team-boot directive into project-level AGENTS.md at DIR
+#   --name NAME         Team name for scaffold (default: "My Team")
+#
+# Library functions (sourced by other skills' setup scripts, not CLI flags):
+#   resolve_sdd_docs_location, sdd_project_subfolder_name, git_publish_workflow
+set -euo pipefail
+
+###############################################################################
+# 1. PATH RESOLUTION
+###############################################################################
+
+resolve_paths() {
+  PROJECT_ROOT="${PROJECT_ROOT:-$([[ -d ".adlc" ]] && pwd || git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  BRANCH="${BRANCH:-$(git branch --show-current 2>/dev/null || echo 'unknown')}"
+  TEAM_AI_DIRECTIVES=""
+
+  # 1. Check TEAM_AI_DIRECTIVES env var (highest priority)
+  if [[ -n "${TEAM_AI_DIRECTIVES:-}" ]]; then
+    TEAM_AI_DIRECTIVES="$TEAM_AI_DIRECTIVES"
+  fi
+
+  # 2. Check .adlc/init-options.json
+  if [[ -z "$TEAM_AI_DIRECTIVES" ]]; then
+    INIT_OPTIONS="${PROJECT_ROOT}/.adlc/init-options.json"
+    if [[ -f "$INIT_OPTIONS" ]]; then
+      TEAM_AI_DIRECTIVES=$(python3 -c "
+import json, sys
+try:
+    with open('$INIT_OPTIONS') as f:
+        print(json.load(f).get('team_ai_directives', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+    fi
+  fi
+
+  # 3. Fallback to default path
+  if [[ -z "$TEAM_AI_DIRECTIVES" ]]; then
+    TEAM_AI_DIRECTIVES="${PROJECT_ROOT}/team-ai-directives"
+  fi
+
+  echo "PROJECT_ROOT=$PROJECT_ROOT"
+  echo "TEAM_AI_DIRECTIVES=$TEAM_AI_DIRECTIVES"
+  echo "BRANCH=$BRANCH"
+}
+
+output_json() {
+  printf '{"REPO_ROOT": "%s", "TEAM_AI_DIRECTIVES": "%s", "BRANCH": "%s", "SDD_DOCS_LOCATION": "%s"}\n' \
+    "$PROJECT_ROOT" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$SDD_DOCS_LOCATION"
+}
+
+resolve_sdd_docs_location() {
+  local project_root="${1:-$PROJECT_ROOT}"
+  local sdd_docs_location=""
+
+  # 1. Environment variable (highest priority)
+  if [[ -n "${SDD_DOCS_LOCATION:-}" ]]; then
+    sdd_docs_location="$SDD_DOCS_LOCATION"
+  fi
+
+  # 2. .adlc/init-options.json
+  if [[ -z "$sdd_docs_location" ]]; then
+    local init_options="${project_root}/.adlc/init-options.json"
+    if [[ -f "$init_options" ]]; then
+      sdd_docs_location=$(python3 -c "
+import json, sys
+try:
+    with open('$init_options') as f:
+        print(json.load(f).get('sdd_docs_location', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+    fi
+  fi
+
+  # 3. Default empty (project root)
+  echo "$sdd_docs_location"
+}
+
+sdd_project_subfolder_name() {
+  local project_root="${1:-$PROJECT_ROOT}"
+  local common_dir
+  common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$common_dir" ]]; then
+    basename "$(cd "$(dirname "$common_dir")" && pwd)"
+  else
+    basename "$project_root"
+  fi
+}
+
+resolve_sdd_root() {
+  local project_root="${1:-$PROJECT_ROOT}"
+  local sdd_docs_location
+  local project_subfolder
+
+  sdd_docs_location=$(resolve_sdd_docs_location "$project_root")
+
+  if [[ -n "$sdd_docs_location" ]]; then
+    # Expand tilde to $HOME
+    sdd_docs_location="${sdd_docs_location/#\~/$HOME}"
+    project_subfolder=$(sdd_project_subfolder_name "$project_root")
+    echo "${sdd_docs_location%/}/${project_subfolder}"
+  else
+    echo "$project_root"
+  fi
+}
+
+### DEPRECATED — kept for backward compatibility
+# Use resolve_sdd_root() and resolve_sdd_docs_location() for new code.
+
+###############################################################################
+# 2. TEAM AI DIRECTIVES STRUCTURE VALIDATION
+###############################################################################
+
+validate_team_ai_directives() {
+  local dir="$1"
+  local missing=0
+
+  for required in \
+    "context_modules/constitution.md" \
+    "context_modules/rules" \
+    "context_modules/personas" \
+    "context_modules/examples" \
+    "CDR.md" \
+    ".skills.json"; do
+    if [[ ! -e "${dir}/${required}" ]]; then
+      echo "MISSING: ${required}"
+      missing=$((missing + 1))
+    fi
+  done
+
+  return "$missing"
+}
+
+###############################################################################
+# 3. SCAFFOLD
+###############################################################################
+
+scaffold_team_ai_directives() {
+  local dest="$1"
+  local team_name="${2:-My Team}"
+  local today
+  today=$(date +%Y-%m-%d)
+
+  if [[ -d "$dest" && -n "$(ls -A "$dest" 2>/dev/null)" ]]; then
+    echo "ERROR: Destination '$dest' already exists and is not empty." >&2
+    exit 1
+  fi
+
+  mkdir -p "${dest}/context_modules/rules"
+  mkdir -p "${dest}/context_modules/personas"
+  mkdir -p "${dest}/context_modules/examples"
+  mkdir -p "${dest}/skills"
+
+  cat > "${dest}/README.md" << README
+# ${team_name} Team AI Directives
+
+Team AI directives repository for ${team_name}.
+
+## Getting Started
+
+1. Wire this directives repository into a project:
+   \`\`\`
+   /team-setup
+   \`\`\`
+   Choose "Point to existing local path" and select this directory.
+
+2. Add context modules to \`context_modules/\` (rules, personas, examples).
+
+3. Add skills to \`skills/\` and register them in \`.skills.json\`.
+
+4. Update \`CDR.md\` as context modules are approved.
+
+See [ADLC Team Skills](https://github.com/tikalk/adlc-team-skills) for full documentation.
+README
+
+  cat > "${dest}/AGENTS.md" << 'AGENTS'
+# Agent Instructions
+
+## Structure
+
+- `context_modules/constitution.md` — Team constitution
+- `context_modules/rules/` — Team rules and workflows
+- `context_modules/personas/` — Team personas
+- `context_modules/examples/` — Team examples
+- `skills/` — Team skills
+- `evals/` — Directive compliance goldensets (pass/fail cases)
+- `CDR.md` — Context Directive Records
+
+## Loading Order
+
+1. Load constitution.md first
+2. Load relevant rules for the current task
+3. Load relevant personas for the current task
+4. Load relevant examples for the current task
+
+## Using Skills
+
+Skills are located in the `skills/` directory. Browse available skills using team-skills and install them as needed.
+
+## CDR.md
+
+The CDR.md file tracks approved context contributions. Update it when adding new context modules.
+AGENTS
+
+  cat > "${dest}/CDR.md" << CDR
+# Context Directive Records
+
+Context Directive Records (CDRs) track decisions about contributing context modules (rules, personas, examples, skills) to team-ai-directives.
+
+## CDR Index
+
+| ID | Target Module | Type | Status | Created | Verified | Age | Descriptor |
+|----|---------------|------|--------|---------|----------|-----|------------|
+
+**Stats**: 0 entries | Last Updated: ${today}
+CDR
+
+  cat > "${dest}/.skills.json" << 'SKILLSJSON'
+{
+  "version": "2.0.0",
+  "source": "team-ai-directives",
+  "description": "Team skills manifest. The `default` list contains skill names that are auto-installed during project setup. The `external` map contains on-demand skills fetched by URL. The `blocked` list contains skills that must never be installed.",
+  "default": [],
+  "external": {},
+  "blocked": [],
+  "policy": {
+    "auto_install_default": true,
+    "enforce_blocked": true,
+    "allow_project_override": true
+  }
+}
+SKILLSJSON
+
+  cat > "${dest}/.mcp.json.example" << 'MCPJSON'
+{
+  "mcpServers": {}
+}
+MCPJSON
+
+  cat > "${dest}/context_modules/constitution.md" << CONSTITUTION
+---
+type: Constitution
+title: "${team_name} Constitution"
+description: "Team-wide principles and governance"
+resource: ./context_modules/constitution.md
+tags: [constitution]
+timestamp: ${today}T00:00:00Z
+---
+
+# ${team_name} Constitution
+
+No team-wide principles defined yet. Add principles as they are established.
+CONSTITUTION
+
+  cat > "${dest}/context_modules/index.md" << 'INDEXTOP'
+# Context Modules
+
+| Directory | Description |
+|-----------|-------------|
+| [rules/](rules/index.md) | Team rules and workflows |
+| [personas/](personas/index.md) | Team personas |
+| [examples/](examples/index.md) | Team examples |
+INDEXTOP
+
+  cat > "${dest}/context_modules/rules/index.md" << 'INDEXRULES'
+# Rules
+
+No rules defined yet. Use /levelup-specify to create rules via CDRs.
+INDEXRULES
+
+  cat > "${dest}/context_modules/personas/index.md" << 'INDEXPERS'
+# Personas
+
+No personas defined yet. Use /levelup-specify to create personas via CDRs.
+INDEXPERS
+
+  cat > "${dest}/context_modules/examples/index.md" << 'INDEXEX'
+# Examples
+
+No examples defined yet. Use /levelup-specify to create examples via CDRs.
+INDEXEX
+
+  touch "${dest}/context_modules/rules/.gitkeep"
+  touch "${dest}/context_modules/personas/.gitkeep"
+  touch "${dest}/context_modules/examples/.gitkeep"
+  touch "${dest}/skills/.gitkeep"
+
+  echo "Scaffolded team-ai-directives at ${dest}"
+  echo "Team name: ${team_name}"
+  echo "Files created: 14"
+
+  validate_team_ai_directives "$dest" || true
+}
+
+scaffold_agents_only() {
+  local dest="$1"
+  mkdir -p "$dest"
+
+  cat > "${dest}/AGENTS.md" << 'AGENTS'
+# Agent Instructions
+
+## Structure
+
+- `context_modules/constitution.md` — Team constitution
+- `context_modules/rules/` — Team rules and workflows
+- `context_modules/personas/` — Team personas
+- `context_modules/examples/` — Team examples
+- `skills/` — Team skills
+- `traces/` — Published session traces (from `/levelup-publish`)
+- `CDR.md` — Context Directive Records
+
+## Loading Order
+
+1. Load constitution.md first
+2. Load relevant rules for the current task
+3. Load relevant personas for the current task
+4. Load relevant examples for the current task
+
+## Using Skills
+
+Skills are located in the `skills/` directory. Browse available skills using team-skills and install them as needed.
+
+## CDR.md
+
+The CDR.md file tracks approved context contributions. Update it when adding new context modules.
+AGENTS
+
+  echo "Created AGENTS.md at ${dest}"
+}
+
+###############################################################################
+# 4. INJECT PROJECT-LEVEL AGENTS.md DIRECTIVE
+###############################################################################
+
+inject_project_agents() {
+  local project_root="${1:-.}"
+  local team_directive="${2:-}"
+
+  # Resolve team_ai_directives if not provided
+  if [[ -z "$team_directive" ]]; then
+    local init_options="${project_root}/.adlc/init-options.json"
+    if [[ -f "$init_options" ]]; then
+      team_directive=$(python3 -c "
+import json, sys
+try:
+    with open('$init_options') as f:
+        print(json.load(f).get('team_ai_directives', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+    fi
+  fi
+
+  # Fallback to env var
+  if [[ -z "$team_directive" ]] && [[ -n "${TEAM_AI_DIRECTIVES:-}" ]]; then
+    team_directive="$TEAM_AI_DIRECTIVES"
+  fi
+
+  # Fallback to default path
+  if [[ -z "$team_directive" ]]; then
+    team_directive="${project_root}/team-ai-directives"
+  fi
+
+  local agents_file="${project_root}/AGENTS.md"
+  local marker_start="<!-- TEAM_AI_DIRECTIVES START -->"
+  local marker_end="<!-- TEAM_AI_DIRECTIVES END -->"
+
+  # Build the managed section
+  local section
+  section=$(cat <<SECTION
+${marker_start}
+## Team Directives & Constitution
+
+This project is bound by the team AI directives repository at \`${team_directive}\`.
+- **Strict Compliance**: You MUST invoke the \`team-boot\` skill BEFORE responding to any task or question. This is not optional and applies to every interaction. If a skill applies, you MUST invoke it immediately.
+- **First-Tool-Call Gate**: Your FIRST tool call in any session MUST be \`skill({name: "team-boot"})\`. If your first tool call is \`read\`, \`grep\`, \`glob\`, \`bash\`, or any other tool, you have VIOLATED this directive -- stop and invoke \`team-boot\` before continuing. Mechanically verifiable in any trace.
+- **Plan-Mode Compatibility**: Loading a skill is read-only -- it injects instructions, it does NOT modify files. Plan mode / read-only phase NEVER forbids the \`skill\` tool. Do not fabricate a conflict between plan mode and the skill check.
+- **Anti-Patterns** (do NOT rationalize skipping the skill check):
+  - "Let me explore the codebase first" -> Skills tell you HOW to explore. Check first.
+  - "This is a plain message, not a spec command" -> Skill check applies to EVERY interaction.
+  - "I will check after understanding the request" -> Check BEFORE understanding -- skills guide your questions.
+  - "This is too simple" -> Simple things become complex. Check first.
+  - "Plan mode forbids modifications" -> The \`skill\` tool is read-only; plan mode never forbids it.
+  - "I need to be efficient / focus on the task" -> The check IS the first step, not overhead to optimize away.
+  - "The task matters more than the check" -> The check IS part of the task; skipping it is a violation.
+- **Team Constitution**: Read and strictly adhere to the principles in \`${team_directive}/context_modules/constitution.md\`. When creating or updating the project constitution, you MUST inherit and align with these principles.
+- **Rules, Personas & Examples**: Use the \`team-discover\` skill to find and load relevant rules, personas, or examples before making changes.
+- **Tech Radar Guidance**: Use the \`tech-radar-context\` skill whenever evaluating or choosing technologies, frameworks, databases, libraries, or cloud infrastructure.
+${marker_end}
+SECTION
+)
+
+  # Create AGENTS.md if it doesn't exist, or update the managed section
+  python3 - "$agents_file" "$marker_start" "$marker_end" "$section" <<'PY'
+import os, sys
+
+agents_path, start, end, section_content = sys.argv[1:5]
+
+if os.path.exists(agents_path):
+    with open(agents_path, "r", encoding="utf-8") as f:
+        content = f.read()
+else:
+    content = ""
+
+# Check if markers already exist
+s_idx = content.find(start)
+e_idx = content.find(end)
+
+if s_idx != -1 and e_idx != -1 and s_idx < e_idx:
+    # Replace existing managed section
+    new_content = content[:s_idx] + section_content + content[e_idx + len(end):]
+    if new_content.endswith("\n"):
+        new_content += "\n"
+    elif not new_content.endswith("\n\n"):
+        new_content += "\n"
+    with open(agents_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print(f"Updated team AI directives section in {agents_path}")
+else:
+    # Append managed section
+    if content and not content.endswith("\n"):
+        content += "\n"
+    if content and not content.endswith("\n\n"):
+        content += "\n"
+    content += section_content + "\n"
+    with open(agents_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    print(f"Injected team AI directives section into {agents_path}")
+PY
+}
+
+###############################################################################
+# 5. SHARED GIT PUBLISH WORKFLOW
+###############################################################################
+
+# Reusable branch/commit/push/PR decision tree extracted from levelup-publish.
+# Usage: git_publish_workflow <target_dir> <branch_prefix> <commit_msg> [<ready_flag>]
+# Emits PUBLISH_OUTCOME=<draft_pr|ready_pr|push_only|local_only|git_init_offered>
+# and PR_URL=<url> when applicable.
+git_publish_workflow() {
+  local target_dir="$1"
+  local branch_prefix="$2"
+  local commit_msg="$3"
+  local ready="${4:-}"
+  local project_name
+  project_name=$(basename "${PROJECT_ROOT:-$(pwd)}")
+  local branch_name="${branch_prefix}/${project_name}"
+
+  # Case D: target is not a git repository — offer git init or write-only/no-op.
+  if ! git -C "$target_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "PUBLISH_OUTCOME=git_init_offered"
+    echo "TARGET_DIR=$target_dir"
+    cat <<MSG
+Target directory is not a git repository. Options:
+
+1. Initialize git and commit:
+   cd "$target_dir"
+   git init
+   git add -A
+   git commit -m "Initial commit"
+   git checkout -b "$branch_name"
+
+2. Write files only (skip git operations).
+MSG
+    return 0
+  fi
+
+  # Create branch (use main if it exists, otherwise HEAD).
+  git -C "$target_dir" checkout -b "$branch_name" main 2>/dev/null || \
+    git -C "$target_dir" checkout -b "$branch_name"
+
+  # Commit changes if there is anything to commit.
+  if [[ -n "$(git -C "$target_dir" status --porcelain 2>/dev/null)" ]]; then
+    git -C "$target_dir" add -A
+    git -C "$target_dir" commit -m "$commit_msg"
+  fi
+
+  # Check for remote "origin".
+  if git -C "$target_dir" remote get-url origin >/dev/null 2>&1; then
+    git -C "$target_dir" push -u origin "$branch_name"
+
+    # Case A: remote + gh CLI available.
+    if command -v gh >/dev/null 2>&1; then
+      local pr_title
+      pr_title=$(echo "$commit_msg" | head -n 1)
+      local pr_body="$commit_msg"
+      local draft_flag="--draft"
+      [[ "$ready" == "--ready" ]] && draft_flag=""
+      local pr_url
+      pr_url=$(cd "$target_dir" && gh pr create $draft_flag --title "$pr_title" --body "$pr_body" 2>/dev/null || true)
+      if [[ -n "$pr_url" ]]; then
+        if [[ "$ready" == "--ready" ]]; then
+          echo "PUBLISH_OUTCOME=ready_pr PR_URL=$pr_url"
+        else
+          echo "PUBLISH_OUTCOME=draft_pr PR_URL=$pr_url"
+        fi
+      else
+        echo "PUBLISH_OUTCOME=push_only"
+        echo "MESSAGE=Pushed to origin/$branch_name. Open a PR manually at your Git host."
+      fi
+    else
+      # Case B: remote exists but gh is not available.
+      echo "PUBLISH_OUTCOME=push_only"
+      echo "MESSAGE=Pushed to origin/$branch_name. Open a PR manually at your Git host."
+    fi
+  else
+    # Case C: no remote exists.
+    echo "PUBLISH_OUTCOME=local_only"
+    echo "MESSAGE=Committed to local branch $branch_name. Add a remote (git remote add origin <url>) and push when ready."
+  fi
+}
+
+###############################################################################
+# MAIN
+###############################################################################
+
+main() {
+  local has_json=false
+  local has_scaffold=false
+  local has_agents_only=false
+  local has_inject_agents=false
+  local scaffold_dest=""
+  local agents_only_dest=""
+  local inject_dest=""
+  local team_name="My Team"
+  local parsing_scaffold=false
+  local parsing_agents=false
+  local parsing_name=false
+  local parsing_inject=false
+
+  for arg in "$@"; do
+    if [[ "$arg" == "--json" || "$arg" == "-Json" ]]; then
+      has_json=true
+      continue
+    fi
+    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+      echo "Usage: team-helpers.sh [--json] [--scaffold DIR] [--agents-only DIR] [--inject-agents [DIR]] [--name NAME]"
+      exit 0
+    fi
+    if [[ "$arg" == "--scaffold" ]]; then
+      has_scaffold=true
+      parsing_scaffold=true
+      parsing_agents=false
+      parsing_name=false
+      parsing_inject=false
+      continue
+    fi
+    if [[ "$arg" == "--agents-only" ]]; then
+      has_agents_only=true
+      parsing_agents=true
+      parsing_scaffold=false
+      parsing_name=false
+      parsing_inject=false
+      continue
+    fi
+    if [[ "$arg" == "--inject-agents" ]]; then
+      has_inject_agents=true
+      parsing_inject=true
+      parsing_scaffold=false
+      parsing_agents=false
+      parsing_name=false
+      continue
+    fi
+    if [[ "$arg" == "--name" ]]; then
+      parsing_name=true
+      parsing_scaffold=false
+      parsing_agents=false
+      parsing_inject=false
+      continue
+    fi
+    if $parsing_scaffold && [[ -n "$arg" ]]; then
+      scaffold_dest="$arg"
+      parsing_scaffold=false
+      continue
+    fi
+    if $parsing_agents && [[ -n "$arg" ]]; then
+      agents_only_dest="$arg"
+      parsing_agents=false
+      continue
+    fi
+    if $parsing_inject && [[ -n "$arg" ]]; then
+      inject_dest="$arg"
+      parsing_inject=false
+      continue
+    fi
+    if $parsing_name && [[ -n "$arg" ]]; then
+      team_name="$arg"
+      parsing_name=false
+      continue
+    fi
+  done
+
+  if $has_scaffold; then
+    if [[ -z "$scaffold_dest" ]]; then
+      echo "ERROR: --scaffold requires a destination directory argument" >&2
+      exit 1
+    fi
+    scaffold_team_ai_directives "$scaffold_dest" "$team_name"
+    return
+  fi
+
+  if $has_agents_only; then
+    if [[ -z "$agents_only_dest" ]]; then
+      echo "ERROR: --agents-only requires a destination directory argument" >&2
+      exit 1
+    fi
+    scaffold_agents_only "$agents_only_dest"
+    return
+  fi
+
+  if $has_inject_agents; then
+    local project_root="${inject_dest:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+    inject_project_agents "$project_root"
+    return
+  fi
+
+  # Default: resolve paths
+  resolve_paths > /dev/null
+  SDD_DOCS_LOCATION=$(resolve_sdd_docs_location "$PROJECT_ROOT")
+  if $has_json; then
+    output_json
+  else
+    resolve_paths
+    echo "SDD_DOCS_LOCATION=$SDD_DOCS_LOCATION"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This PR adds cross-skill support for an external SDD docs location and introduces shared team helpers.

### What's changed
- Architect, evals, levelup, and product setup scripts (Bash and PowerShell) now resolve "SDD_DOCS_LOCATION" (env var or ".adlc/init-options.json") and write SDD artifacts to a per-project subfolder when set.
- Added a new "sdd-docs" skill with Bash and PowerShell setup scripts for publishing SDD docs.
- Added shared "team-helpers.sh" / "team-helpers.ps1" utilities used by the updated setup scripts.
- Updated SKILL.md documentation and README to reflect the new SDD docs location behavior.

### Verification
- Confirmed no setup script derives the project subfolder from "remote.origin.url".
- Confirmed PowerShell scripts now use "git -C $ProjectRoot rev-parse --git-common-dir" to match the Bash behavior.

Closes SDD docs-location integration work.