### PR TITLE
docs(team): clarify native discovery + superpowers coexistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] - 2026-08-05
+
+### Changed
+
+- **`team-boot` clarifies native discovery and `/team-discover` scope** (`skills/team/team-boot/SKILL.md`): the Overview now states explicitly that discovery is native — the injected CDR index is matched by the LLM per prompt with no skill invocation — and that `/team-discover` is a user-invoked command, not part of the bootstrap loop. Added a "Coexistence with other bootstraps" section documenting that team-boot composes with superpowers' `using-superpowers` session-start injection (team-boot governs team-context surfacing; superpowers governs process-skill invocation; both apply simultaneously).
+
+- **`team-discover` documents its relationship to `team-boot`** (`skills/team/team-discover/SKILL.md`): added a "Relationship to team-boot" section making explicit that team-boot does not invoke this skill in its bootstrap loop (discovery is native) and that `/team-discover` is user-invoked for explicit structured re-discovery. Kills the drift between the two skill docs.
+
+- **README documents superpowers coexistence** (`README.md`): added a "Coexistence with superpowers" subsection under Universal Skill & SDD Framework Orchestration, with a concern-ownership table (team context / per-prompt discovery / process skills / skill-check enforcement / SDD lifecycle orchestration) and precedence guidance (`mission-brief` for spec-driven features; superpowers' `executing-plans` / `subagent-driven-development` for ad-hoc coding).
+
 ## [0.23.1] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -192,6 +192,27 @@ npx skills add tikalk/adlc-team-skills
 mission-brief "add user profile API with JWT"
 ```
 
+### Coexistence with superpowers
+
+[superpowers](https://github.com/obra/superpowers) and ADLC Team Skills compose
+without conflict because they own different concerns:
+
+| Concern | Owner |
+| :--- | :--- |
+| Team context (constitution, CDRs, PDR/ADR) + Team Context in Use output contract | `team-boot` (session_start event hook → `boot.sh` lean orientation) |
+| Per-prompt discovery matching | Native — the LLM matches the injected CDR index against the current task; no skill call required |
+| Explicit structured re-discovery | `/team-discover` (user-invoked only) |
+| Generic process skills (brainstorming, writing-plans, TDD, debugging, code-review, worktrees) | superpowers |
+| Session-start skill-check enforcement ("1% rule") | superpowers' `using-superpowers` bootstrap |
+| SDD lifecycle orchestration (specify → clarify → implement ↔ converge) | `mission-brief` + the product/architect/levelup/evals skill families |
+
+Precedence when both could apply: `mission-brief` wins for spec-driven feature
+work; superpowers' `executing-plans` / `subagent-driven-development` serve
+ad-hoc coding tasks. The two session-start injections (team-boot's lean
+orientation and superpowers' `using-superpowers`) apply simultaneously —
+team-boot governs team-context surfacing, superpowers governs process-skill
+invocation.
+
 ---
 
 ## Repository Layout

--- a/skills/team/team-boot/SKILL.md
+++ b/skills/team/team-boot/SKILL.md
@@ -14,6 +14,12 @@ Assembles team AI directives context and injects it into the system prompt
 at session start. The CDR index lists all available team context modules
 with descriptors — read full module files on demand when a task matches.
 
+Discovery is **native**: the injected CDR index is matched by the LLM
+against the current task on its own, per prompt, with no skill invocation.
+`/team-discover` is a separate, **user-invoked** command for explicit
+structured re-discovery (e.g., starting a complex feature) and is not part
+of the bootstrap loop.
+
 ## Event hook (automatic)
 
 The `session_start` event hook runs `scripts/boot.sh` (POSIX) or
@@ -34,6 +40,13 @@ cached content, no accumulation).
    PDR/ADR indexes, and `.skills.json` into your context.
 4. The CDR index is your catalog — read full module bodies on demand
    when a task matches a CDR descriptor.
+
+## Coexistence with other bootstraps
+
+`team-boot` composes with other session-start injections (e.g., superpowers'
+`using-superpowers`): `team-boot` governs team-context surfacing (the Team
+Context in Use table); other bootstraps may govern process-skill invocation.
+Both apply simultaneously — they do not conflict.
 
 ## Unconfigured projects
 

--- a/skills/team/team-discover/SKILL.md
+++ b/skills/team/team-discover/SKILL.md
@@ -9,11 +9,24 @@ description: Manually re-scan team context modules and produce a structured disc
 
 The CDR index is injected into the system prompt at session start by
 team-boot. The LLM natively matches CDR descriptors against the current
-task and reads full module bodies on demand.
+task and reads full module bodies on demand. This native matching happens
+per prompt without invoking this skill.
 
 Use `/team-discover` when you want a structured discovery table with
 explicit relevance assessments — for example, when starting a complex
 feature or verifying which directives apply.
+
+## Relationship to team-boot
+
+`team-boot` is the session bootstrap: it injects the CDR index into the
+system prompt via the `session_start` event hook. Per-prompt discovery
+matching is **native** — the LLM matches the injected CDR index against the
+current message on its own, so `team-boot` does **not** invoke this skill
+as part of its bootstrap loop.
+
+`/team-discover` is **user-invoked**: run it when you want an explicit,
+structured re-scan with a relevance-rated table (complex features, audits, or
+verifying which directives apply). It is not required for normal operation.
 
 ## Process
 


### PR DESCRIPTION
## What

Documents how `team-boot` / `team-discover` relate to native discovery and how ADLC Team Skills coexist with [superpowers](https://github.com/obra/superpowers).

## Why

`team-boot` injects the CDR index into the system prompt at session start, and the LLM matches it natively on every prompt — no `team-discover` skill call is required for per-prompt matching. The two skill docs had drifted: `team-boot` described `team-discover` as a per-prompt engine in some places, while `team-discover` described itself as manual-only. This kills the drift and makes the architecture explicit.

Superpowers (installed separately) provides generic process skills and its own session-start skill-check bootstrap. The two bootstraps compose without conflict because they own different concerns — this PR documents that boundary so users can run both.

## Changes

- **`skills/team/team-boot/SKILL.md`** — Overview now states discovery is native (LLM matches the injected CDR index per prompt, no skill invocation) and `/team-discover` is user-invoked, not part of the bootstrap loop. Added a "Coexistence with other bootstraps" section (composes with superpowers' `using-superpowers`).
- **`skills/team/team-discover/SKILL.md`** — added a "Relationship to team-boot" section making explicit that team-boot does not invoke it in the bootstrap loop and that it is user-invoked for explicit structured re-discovery.
- **`README.md`** — added a "Coexistence with superpowers" subsection under Universal Skill & SDD Framework Orchestration, with a concern-ownership table and precedence guidance (`mission-brief` for spec-driven features; superpowers' `executing-plans` / `subagent-driven-development` for ad-hoc coding).
- **`CHANGELOG.md`** — `[0.23.2]` entry.

## Verification

```
89 passed in 3.93s
```

All existing tests pass (including `test_team_boot_setup_flow.py` — 38/38). No test changes were needed; this is a docs-only PR that aligns the skill docs with the architecture the tests already encode.

## Notes

- Superpowers installation is out of scope — users install it separately (e.g., via OpenCode plugin). This PR only documents the coexistence boundary.
- No changes to `team-ai-directives` repo or the AGENTS.md generator (`team-setup` helpers). The managed block's output contract already matches the native-discovery model.