### PR TITLE
docs(changelog): add spec-kit coexistence guide to 0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`boot.sh` / `boot.ps1` crash on malformed `.skills.json`** (`skills/team/team-boot/scripts/`): the `$(jq ... || echo "0")` pattern concatenated partial jq stdout with the fallback `"0"` when jq exited with a parse error, producing multi-line values like `"16\n0"` that broke the arithmetic on line 58 (`syntax error in expression (error token is "0")`). This caused team-boot `session_start` hook failures across all projects using a directives repo with corrupted JSON. Fixed by separating stdout capture from the fallback (`$(jq ...) || VAR=0`) and validating the result is a pure integer (`[[ "$VAR" =~ ^[0-9]+$ ]]`). Also hardened the `jq ... | while read` iteration pipelines and `CDR_COUNT` with the same pattern, and wrapped `boot.ps1`'s `ConvertFrom-Json` in try/catch so malformed JSON degrades gracefully instead of crashing the script.
 
+### Added
+
+- **Spec-kit coexistence guide** (`docs/spec-kit-integration.md`): documents the recommended install flow for using adlc-team-skills alongside agentic-sdlc-spec-kit without skill/command conflicts. Install adlc-team-skills first, run `/team-setup`, then `specify init` without `--team-ai-directives`.
+
 ### Changed
 
 - **`team-boot` clarifies native discovery and `/team-discover` scope** (`skills/team/team-boot/SKILL.md`): the Overview now states explicitly that discovery is native — the injected CDR index is matched by the LLM per prompt with no skill invocation — and that `/team-discover` is a user-invoked command, not part of the bootstrap loop.


### PR DESCRIPTION
PR #10 included `docs/spec-kit-integration.md` but the CHANGELOG entry for 0.23.4 was not updated to mention it.

Also needed to tag missing releases (0.23.4, 0.24.0) after this merges.