### PR TITLE
fix(architect): missing diagram functions + dot-notation command references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`boot.sh` / `boot.ps1` crash on malformed `.skills.json`** (`skills/team/team-boot/scripts/`): the `$(jq ... || echo "0")` pattern concatenated partial jq stdout with the fallback `"0"` when jq exited with a parse error, producing multi-line values like `"16\n0"` that broke the arithmetic on line 58 (`syntax error in expression (error token is "0")`). This caused team-boot `session_start` hook failures across all projects using a directives repo with corrupted JSON. Fixed by separating stdout capture from the fallback (`$(jq ...) || VAR=0`) and validating the result is a pure integer (`[[ "$VAR" =~ ^[0-9]+$ ]]`). Also hardened the `jq ... | while read` iteration pipelines and `CDR_COUNT` with the same pattern, and wrapped `boot.ps1`'s `ConvertFrom-Json` in try/catch so malformed JSON degrades gracefully instead of crashing the script.
 
+### Added
+
+- **Spec-kit coexistence guide** (`docs/spec-kit-integration.md`): documents the recommended install flow for using adlc-team-skills alongside agentic-sdlc-spec-kit without skill/command conflicts. Install adlc-team-skills first, run `/team-setup`, then `specify init` without `--team-ai-directives`.
+
 ### Changed
 
 - **`team-boot` clarifies native discovery and `/team-discover` scope** (`skills/team/team-boot/SKILL.md`): the Overview now states explicitly that discovery is native — the injected CDR index is matched by the LLM per prompt with no skill invocation — and that `/team-discover` is a user-invoked command, not part of the bootstrap loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1] - 2026-08-08
+
+### Fixed
+
+- **`setup-architect.sh` / `setup-architect.ps1` crash on diagram generation — `get_architecture_diagram_format: command not found`** (`skills/architect/architect-*/scripts/`): the architect scripts were ported from spec-kit, where the large `common.sh`/`common.ps1` defined `get_architecture_diagram_format()` and `validate_mermaid_syntax()` (bash) / `Get-ArchitectureDiagramFormat` and `Test-MermaidSyntax` (PowerShell). The adlc bundled `common.sh` is a minimal 57-line file that never included them, so any action calling `generate_and_insert_diagrams` (e.g. `update`, `map`) died at line 761 with `command not found`. Fixed by adding both functions to the bundled bash `common.sh` (all 5 copies) and both functions inline in the PowerShell `setup-architect.ps1` (all 5 copies). The format is overridable via the `ARCHITECTURE_DIAGRAM_FORMAT` env var (`mermaid`|`ascii`, default `mermaid`), matching the existing `ARCHITECTURE_VIEWS` env var pattern instead of spec-kit's config-file lookup.
+
+### Added
+
+- **Static guard tests for architect diagram helpers** (`tests/unit/test_setup_scripts.py`): `test_architect_common_sh_defines_diagram_functions` + `test_architect_ps1_defines_diagram_functions` verify all 5 bash and all 5 PowerShell copies define the diagram functions, and `test_architect_bash_common_sh_copies_identical` + `test_architect_ps1_setup_copies_identical` lock the 5 copies to stay byte-identical so the shared contract cannot drift.
+
 ## [0.24.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dot-notation skill handover references replaced with hyphenated command names** (`skills/architect/**`, `skills/product/**`): 219 references to spec-kit-style commands (`/architect.init`, `/architect.adlc`, `/architect.implement`, `/architect.clarify`, `/product.init`, `/product.specify`, `/product.clarify`, `/product.implement`, `/product.roadmap`) were dead links — the actual command files in `.opencode/commands/` are hyphenated (`architect-init.md`, `product-specify.md`, …). `/architect.adlc` (stale name for the greenfield command) mapped to `/architect-specify`. All references now point to real commands.
+
 - **`setup-architect.sh` / `setup-architect.ps1` crash on diagram generation — `get_architecture_diagram_format: command not found`** (`skills/architect/architect-*/scripts/`): the architect scripts were ported from spec-kit, where the large `common.sh`/`common.ps1` defined `get_architecture_diagram_format()` and `validate_mermaid_syntax()` (bash) / `Get-ArchitectureDiagramFormat` and `Test-MermaidSyntax` (PowerShell). The adlc bundled `common.sh` is a minimal 57-line file that never included them, so any action calling `generate_and_insert_diagrams` (e.g. `update`, `map`) died at line 761 with `command not found`. Fixed by adding both functions to the bundled bash `common.sh` (all 5 copies) and both functions inline in the PowerShell `setup-architect.ps1` (all 5 copies). The format is overridable via the `ARCHITECTURE_DIAGRAM_FORMAT` env var (`mermaid`|`ascii`, default `mermaid`), matching the existing `ARCHITECTURE_VIEWS` env var pattern instead of spec-kit's config-file lookup.
 
 ### Added
 
-- **Static guard tests for architect diagram helpers** (`tests/unit/test_setup_scripts.py`): `test_architect_common_sh_defines_diagram_functions` + `test_architect_ps1_defines_diagram_functions` verify all 5 bash and all 5 PowerShell copies define the diagram functions, and `test_architect_bash_common_sh_copies_identical` + `test_architect_ps1_setup_copies_identical` lock the 5 copies to stay byte-identical so the shared contract cannot drift.
+- **Static guard tests for architect diagram helpers** (`tests/unit/test_setup_scripts.py`): `test_architect_common_sh_defines_diagram_functions` + `test_architect_ps1_defines_diagram_functions` verify all 5 bash and all 5 PowerShell copies define the diagram functions, and `test_architect_bash_common_sh_copies_identical` + `test_architect_ps1_setup_copies_identical` lock the 5 copies to stay byte-identical so the shared contract cannot drift. `test_no_dot_notation_skill_references` prevents dot-notation command references from creeping back in.
 
 ## [0.24.0] - 2026-08-08
 

--- a/skills/architect/architect-analyze/scripts/bash/common.sh
+++ b/skills/architect/architect-analyze/scripts/bash/common.sh
@@ -55,3 +55,46 @@ get_feature_paths() {
     _seed_templates "$repo_root"
     echo "REPO_ROOT=\"$repo_root\""
 }
+
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+get_architecture_diagram_format() {
+    local format="${ARCHITECTURE_DIAGRAM_FORMAT:-mermaid}"
+    if [[ "$format" == "mermaid" || "$format" == "ascii" ]]; then
+        echo "$format"
+    else
+        echo "mermaid"
+    fi
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation).
+# Returns 0 if valid, 1 if invalid.
+# Args: $1 - Mermaid code string
+validate_mermaid_syntax() {
+    local mermaid_code="$1"
+
+    # Check if empty
+    if [[ -z "$mermaid_code" ]]; then
+        return 1
+    fi
+
+    # Check for basic Mermaid diagram types
+    if ! echo "$mermaid_code" | grep -qE '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)'; then
+        return 1
+    fi
+
+    # Check for balanced brackets/parentheses (simplified)
+    local open_brackets close_brackets open_parens close_parens
+    open_brackets=$(echo "$mermaid_code" | grep -o '\[' | wc -l)
+    close_brackets=$(echo "$mermaid_code" | grep -o '\]' | wc -l)
+    open_parens=$(echo "$mermaid_code" | grep -o '(' | wc -l)
+    close_parens=$(echo "$mermaid_code" | grep -o ')' | wc -l)
+
+    if [[ $open_brackets -ne $close_brackets ]] || [[ $open_parens -ne $close_parens ]]; then
+        return 1
+    fi
+
+    # Basic syntax passed
+    return 0
+}

--- a/skills/architect/architect-analyze/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-analyze/scripts/bash/setup-architect.sh
@@ -861,12 +861,12 @@ action_specify() {
     echo "  2. Ask clarifying questions about architecture" >&2
     echo "  3. Create ADRs for each key decision" >&2
     echo "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)" >&2
-    echo "     (ADRs will be moved to memory/team after /architect.implement)" >&2
+    echo "     (ADRs will be moved to memory/team after /architect-implement)" >&2
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  5. Organize ADRs by sub-system" >&2
     fi
     echo "" >&2
-    echo "After completion, run '/architect.implement' to generate full AD.md" >&2
+    echo "After completion, run '/architect-implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
@@ -901,7 +901,7 @@ action_clarify() {
             active_scope="memory"
         else
             echo "❌ ADR directory does not exist: $adr_dir" >&2
-            echo "Run '/architect.adlc' or '/architect.init' first" >&2
+            echo "Run '/architect-specify' or '/architect-init' first" >&2
             exit 1
         fi
     fi
@@ -941,7 +941,7 @@ action_implement() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1064,10 +1064,10 @@ action_init() {
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  4. Organize ADRs by sub-system" >&2
     fi
-    echo "  5. Auto-trigger /architect.clarify to validate findings" >&2
+    echo "  5. Auto-trigger /architect-clarify to validate findings" >&2
     echo "" >&2
     echo "NOTE: AD.md will NOT be created until ADRs are validated." >&2
-    echo "      After clarification, run /architect.implement to generate AD.md" >&2
+    echo "      After clarification, run /architect-implement to generate AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
@@ -1127,7 +1127,7 @@ action_map() {
 action_update() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1166,7 +1166,7 @@ action_update() {
 action_review() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1353,7 +1353,7 @@ action_plan_dag() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1447,7 +1447,7 @@ action_execute_dag() {
     # Check if state file exists
     if [[ ! -f "$state_file" ]]; then
         echo "❌ No execution plan found: $state_file" >&2
-        echo "Run '/architect.implement' first to generate and approve a DAG plan" >&2
+        echo "Run '/architect-implement' first to generate and approve a DAG plan" >&2
         exit 1
     fi
     
@@ -1490,7 +1490,7 @@ action_summarize() {
     # Check if views directory exists and has content
     if [[ ! -d "$views_dir" ]]; then
         echo "❌ Views directory not found: $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     
@@ -1500,7 +1500,7 @@ action_summarize() {
     
     if [[ "$view_count" -eq 0 ]]; then
         echo "❌ No view files found in $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     

--- a/skills/architect/architect-analyze/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-analyze/scripts/powershell/setup-architect.ps1
@@ -624,12 +624,12 @@ function Invoke-Specify {
     Write-Host "  2. Ask clarifying questions about architecture"
     Write-Host "  3. Create ADRs for each key decision"
     Write-Host "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)"
-    Write-Host "     (ADRs will be moved to .adlc/memory after /architect.implement)"
+    Write-Host "     (ADRs will be moved to .adlc/memory after /architect-implement)"
     if ($Decompose) {
         Write-Host "  5. Organize ADRs by sub-system"
     }
     Write-Host ""
-    Write-Host "After completion, run '/architect.implement' to generate full AD.md"
+    Write-Host "After completion, run '/architect-implement' to generate full AD.md"
     
     if ($Json) {
         @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
@@ -643,7 +643,7 @@ function Invoke-Clarify {
     $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -675,7 +675,7 @@ function Invoke-Implement {
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -808,10 +808,10 @@ function Invoke-Init {
     if ($Decompose) {
         Write-Host "  4. Organize ADRs by sub-system"
     }
-    Write-Host "  5. Auto-trigger /architect.clarify to validate findings"
+    Write-Host "  5. Auto-trigger /architect-clarify to validate findings"
     Write-Host ""
     Write-Host "NOTE: AD.md will NOT be created until ADRs are validated." -ForegroundColor Yellow
-    Write-Host "      After clarification, run /architect.implement to generate AD.md"
+    Write-Host "      After clarification, run /architect-implement to generate AD.md"
     
     if ($Json) {
         @{
@@ -880,7 +880,7 @@ function Invoke-Update {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -920,7 +920,7 @@ function Invoke-Review {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1125,7 +1125,7 @@ function Invoke-PlanDag {
     
     # Check if ADR file exists
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1205,7 +1205,7 @@ function Invoke-ExecuteDag {
     
     # Check if state file exists
     if (-not (Test-Path $stateFile)) {
-        Write-Error "No execution plan found: $stateFile`nRun '/architect.implement' first to generate and approve a DAG plan"
+        Write-Error "No execution plan found: $stateFile`nRun '/architect-implement' first to generate and approve a DAG plan"
         exit 1
     }
     
@@ -1251,7 +1251,7 @@ function Invoke-Summarize {
     
     # Check if views directory exists and has content
     if (-not (Test-Path $viewsDir)) {
-        Write-Error "Views directory not found: $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "Views directory not found: $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     
@@ -1260,7 +1260,7 @@ function Invoke-Summarize {
     $viewCount = $viewFiles.Count
     
     if ($viewCount -eq 0) {
-        Write-Error "No view files found in $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "No view files found in $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     

--- a/skills/architect/architect-analyze/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-analyze/scripts/powershell/setup-architect.ps1
@@ -449,6 +449,51 @@ function Parse-Views {
     }
 }
 
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+function Get-ArchitectureDiagramFormat {
+    $format = $env:ARCHITECTURE_DIAGRAM_FORMAT
+    if ($format -eq 'mermaid' -or $format -eq 'ascii') {
+        return $format
+    }
+    return 'mermaid'
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation)
+# Returns $true if valid, $false if invalid
+# Args: MermaidCode - Mermaid code string
+function Test-MermaidSyntax {
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$MermaidCode
+    )
+
+    # Check if empty
+    if ([string]::IsNullOrWhiteSpace($MermaidCode)) {
+        return $false
+    }
+
+    # Check for basic Mermaid diagram types
+    if ($MermaidCode -notmatch '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)') {
+        return $false
+    }
+
+    # Check for balanced brackets/parentheses (simplified)
+    $openBrackets = ([regex]::Matches($MermaidCode, '\[')).Count
+    $closeBrackets = ([regex]::Matches($MermaidCode, '\]')).Count
+    $openParens = ([regex]::Matches($MermaidCode, '\(')).Count
+    $closeParens = ([regex]::Matches($MermaidCode, '\)')).Count
+
+    if ($openBrackets -ne $closeBrackets -or $openParens -ne $closeParens) {
+        return $false
+    }
+
+    # Basic syntax passed
+    return $true
+}
+
 # Generate and insert diagrams into architecture.md
 function New-ArchitectureDiagrams {
     param(

--- a/skills/architect/architect-clarify/SKILL.md
+++ b/skills/architect/architect-clarify/SKILL.md
@@ -29,7 +29,7 @@ Use this skill:
 Do **not** use this skill when:
 
 - **No ADRs exist**: Use `/architect-init` first to create ADRs
-- **Brownfield projects**: Use `/architect.init` to reverse-engineer ADRs from code
+- **Brownfield projects**: Use `/architect-init` to reverse-engineer ADRs from code
 
 ## Process
 

--- a/skills/architect/architect-clarify/scripts/bash/common.sh
+++ b/skills/architect/architect-clarify/scripts/bash/common.sh
@@ -55,3 +55,46 @@ get_feature_paths() {
     _seed_templates "$repo_root"
     echo "REPO_ROOT=\"$repo_root\""
 }
+
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+get_architecture_diagram_format() {
+    local format="${ARCHITECTURE_DIAGRAM_FORMAT:-mermaid}"
+    if [[ "$format" == "mermaid" || "$format" == "ascii" ]]; then
+        echo "$format"
+    else
+        echo "mermaid"
+    fi
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation).
+# Returns 0 if valid, 1 if invalid.
+# Args: $1 - Mermaid code string
+validate_mermaid_syntax() {
+    local mermaid_code="$1"
+
+    # Check if empty
+    if [[ -z "$mermaid_code" ]]; then
+        return 1
+    fi
+
+    # Check for basic Mermaid diagram types
+    if ! echo "$mermaid_code" | grep -qE '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)'; then
+        return 1
+    fi
+
+    # Check for balanced brackets/parentheses (simplified)
+    local open_brackets close_brackets open_parens close_parens
+    open_brackets=$(echo "$mermaid_code" | grep -o '\[' | wc -l)
+    close_brackets=$(echo "$mermaid_code" | grep -o '\]' | wc -l)
+    open_parens=$(echo "$mermaid_code" | grep -o '(' | wc -l)
+    close_parens=$(echo "$mermaid_code" | grep -o ')' | wc -l)
+
+    if [[ $open_brackets -ne $close_brackets ]] || [[ $open_parens -ne $close_parens ]]; then
+        return 1
+    fi
+
+    # Basic syntax passed
+    return 0
+}

--- a/skills/architect/architect-clarify/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-clarify/scripts/bash/setup-architect.sh
@@ -861,12 +861,12 @@ action_specify() {
     echo "  2. Ask clarifying questions about architecture" >&2
     echo "  3. Create ADRs for each key decision" >&2
     echo "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)" >&2
-    echo "     (ADRs will be moved to memory/team after /architect.implement)" >&2
+    echo "     (ADRs will be moved to memory/team after /architect-implement)" >&2
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  5. Organize ADRs by sub-system" >&2
     fi
     echo "" >&2
-    echo "After completion, run '/architect.implement' to generate full AD.md" >&2
+    echo "After completion, run '/architect-implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
@@ -901,7 +901,7 @@ action_clarify() {
             active_scope="memory"
         else
             echo "❌ ADR directory does not exist: $adr_dir" >&2
-            echo "Run '/architect.adlc' or '/architect.init' first" >&2
+            echo "Run '/architect-specify' or '/architect-init' first" >&2
             exit 1
         fi
     fi
@@ -941,7 +941,7 @@ action_implement() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1064,10 +1064,10 @@ action_init() {
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  4. Organize ADRs by sub-system" >&2
     fi
-    echo "  5. Auto-trigger /architect.clarify to validate findings" >&2
+    echo "  5. Auto-trigger /architect-clarify to validate findings" >&2
     echo "" >&2
     echo "NOTE: AD.md will NOT be created until ADRs are validated." >&2
-    echo "      After clarification, run /architect.implement to generate AD.md" >&2
+    echo "      After clarification, run /architect-implement to generate AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
@@ -1127,7 +1127,7 @@ action_map() {
 action_update() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1166,7 +1166,7 @@ action_update() {
 action_review() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1353,7 +1353,7 @@ action_plan_dag() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1447,7 +1447,7 @@ action_execute_dag() {
     # Check if state file exists
     if [[ ! -f "$state_file" ]]; then
         echo "❌ No execution plan found: $state_file" >&2
-        echo "Run '/architect.implement' first to generate and approve a DAG plan" >&2
+        echo "Run '/architect-implement' first to generate and approve a DAG plan" >&2
         exit 1
     fi
     
@@ -1490,7 +1490,7 @@ action_summarize() {
     # Check if views directory exists and has content
     if [[ ! -d "$views_dir" ]]; then
         echo "❌ Views directory not found: $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     
@@ -1500,7 +1500,7 @@ action_summarize() {
     
     if [[ "$view_count" -eq 0 ]]; then
         echo "❌ No view files found in $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     

--- a/skills/architect/architect-clarify/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-clarify/scripts/powershell/setup-architect.ps1
@@ -624,12 +624,12 @@ function Invoke-Specify {
     Write-Host "  2. Ask clarifying questions about architecture"
     Write-Host "  3. Create ADRs for each key decision"
     Write-Host "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)"
-    Write-Host "     (ADRs will be moved to .adlc/memory after /architect.implement)"
+    Write-Host "     (ADRs will be moved to .adlc/memory after /architect-implement)"
     if ($Decompose) {
         Write-Host "  5. Organize ADRs by sub-system"
     }
     Write-Host ""
-    Write-Host "After completion, run '/architect.implement' to generate full AD.md"
+    Write-Host "After completion, run '/architect-implement' to generate full AD.md"
     
     if ($Json) {
         @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
@@ -643,7 +643,7 @@ function Invoke-Clarify {
     $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -675,7 +675,7 @@ function Invoke-Implement {
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -808,10 +808,10 @@ function Invoke-Init {
     if ($Decompose) {
         Write-Host "  4. Organize ADRs by sub-system"
     }
-    Write-Host "  5. Auto-trigger /architect.clarify to validate findings"
+    Write-Host "  5. Auto-trigger /architect-clarify to validate findings"
     Write-Host ""
     Write-Host "NOTE: AD.md will NOT be created until ADRs are validated." -ForegroundColor Yellow
-    Write-Host "      After clarification, run /architect.implement to generate AD.md"
+    Write-Host "      After clarification, run /architect-implement to generate AD.md"
     
     if ($Json) {
         @{
@@ -880,7 +880,7 @@ function Invoke-Update {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -920,7 +920,7 @@ function Invoke-Review {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1125,7 +1125,7 @@ function Invoke-PlanDag {
     
     # Check if ADR file exists
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1205,7 +1205,7 @@ function Invoke-ExecuteDag {
     
     # Check if state file exists
     if (-not (Test-Path $stateFile)) {
-        Write-Error "No execution plan found: $stateFile`nRun '/architect.implement' first to generate and approve a DAG plan"
+        Write-Error "No execution plan found: $stateFile`nRun '/architect-implement' first to generate and approve a DAG plan"
         exit 1
     }
     
@@ -1251,7 +1251,7 @@ function Invoke-Summarize {
     
     # Check if views directory exists and has content
     if (-not (Test-Path $viewsDir)) {
-        Write-Error "Views directory not found: $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "Views directory not found: $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     
@@ -1260,7 +1260,7 @@ function Invoke-Summarize {
     $viewCount = $viewFiles.Count
     
     if ($viewCount -eq 0) {
-        Write-Error "No view files found in $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "No view files found in $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     

--- a/skills/architect/architect-clarify/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-clarify/scripts/powershell/setup-architect.ps1
@@ -449,6 +449,51 @@ function Parse-Views {
     }
 }
 
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+function Get-ArchitectureDiagramFormat {
+    $format = $env:ARCHITECTURE_DIAGRAM_FORMAT
+    if ($format -eq 'mermaid' -or $format -eq 'ascii') {
+        return $format
+    }
+    return 'mermaid'
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation)
+# Returns $true if valid, $false if invalid
+# Args: MermaidCode - Mermaid code string
+function Test-MermaidSyntax {
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$MermaidCode
+    )
+
+    # Check if empty
+    if ([string]::IsNullOrWhiteSpace($MermaidCode)) {
+        return $false
+    }
+
+    # Check for basic Mermaid diagram types
+    if ($MermaidCode -notmatch '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)') {
+        return $false
+    }
+
+    # Check for balanced brackets/parentheses (simplified)
+    $openBrackets = ([regex]::Matches($MermaidCode, '\[')).Count
+    $closeBrackets = ([regex]::Matches($MermaidCode, '\]')).Count
+    $openParens = ([regex]::Matches($MermaidCode, '\(')).Count
+    $closeParens = ([regex]::Matches($MermaidCode, '\)')).Count
+
+    if ($openBrackets -ne $closeBrackets -or $openParens -ne $closeParens) {
+        return $false
+    }
+
+    # Basic syntax passed
+    return $true
+}
+
 # Generate and insert diagrams into architecture.md
 function New-ArchitectureDiagrams {
     param(

--- a/skills/architect/architect-implement/scripts/bash/common.sh
+++ b/skills/architect/architect-implement/scripts/bash/common.sh
@@ -55,3 +55,46 @@ get_feature_paths() {
     _seed_templates "$repo_root"
     echo "REPO_ROOT=\"$repo_root\""
 }
+
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+get_architecture_diagram_format() {
+    local format="${ARCHITECTURE_DIAGRAM_FORMAT:-mermaid}"
+    if [[ "$format" == "mermaid" || "$format" == "ascii" ]]; then
+        echo "$format"
+    else
+        echo "mermaid"
+    fi
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation).
+# Returns 0 if valid, 1 if invalid.
+# Args: $1 - Mermaid code string
+validate_mermaid_syntax() {
+    local mermaid_code="$1"
+
+    # Check if empty
+    if [[ -z "$mermaid_code" ]]; then
+        return 1
+    fi
+
+    # Check for basic Mermaid diagram types
+    if ! echo "$mermaid_code" | grep -qE '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)'; then
+        return 1
+    fi
+
+    # Check for balanced brackets/parentheses (simplified)
+    local open_brackets close_brackets open_parens close_parens
+    open_brackets=$(echo "$mermaid_code" | grep -o '\[' | wc -l)
+    close_brackets=$(echo "$mermaid_code" | grep -o '\]' | wc -l)
+    open_parens=$(echo "$mermaid_code" | grep -o '(' | wc -l)
+    close_parens=$(echo "$mermaid_code" | grep -o ')' | wc -l)
+
+    if [[ $open_brackets -ne $close_brackets ]] || [[ $open_parens -ne $close_parens ]]; then
+        return 1
+    fi
+
+    # Basic syntax passed
+    return 0
+}

--- a/skills/architect/architect-implement/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-implement/scripts/bash/setup-architect.sh
@@ -861,12 +861,12 @@ action_specify() {
     echo "  2. Ask clarifying questions about architecture" >&2
     echo "  3. Create ADRs for each key decision" >&2
     echo "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)" >&2
-    echo "     (ADRs will be moved to memory/team after /architect.implement)" >&2
+    echo "     (ADRs will be moved to memory/team after /architect-implement)" >&2
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  5. Organize ADRs by sub-system" >&2
     fi
     echo "" >&2
-    echo "After completion, run '/architect.implement' to generate full AD.md" >&2
+    echo "After completion, run '/architect-implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
@@ -901,7 +901,7 @@ action_clarify() {
             active_scope="memory"
         else
             echo "❌ ADR directory does not exist: $adr_dir" >&2
-            echo "Run '/architect.adlc' or '/architect.init' first" >&2
+            echo "Run '/architect-specify' or '/architect-init' first" >&2
             exit 1
         fi
     fi
@@ -941,7 +941,7 @@ action_implement() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1064,10 +1064,10 @@ action_init() {
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  4. Organize ADRs by sub-system" >&2
     fi
-    echo "  5. Auto-trigger /architect.clarify to validate findings" >&2
+    echo "  5. Auto-trigger /architect-clarify to validate findings" >&2
     echo "" >&2
     echo "NOTE: AD.md will NOT be created until ADRs are validated." >&2
-    echo "      After clarification, run /architect.implement to generate AD.md" >&2
+    echo "      After clarification, run /architect-implement to generate AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
@@ -1127,7 +1127,7 @@ action_map() {
 action_update() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1166,7 +1166,7 @@ action_update() {
 action_review() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1353,7 +1353,7 @@ action_plan_dag() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1447,7 +1447,7 @@ action_execute_dag() {
     # Check if state file exists
     if [[ ! -f "$state_file" ]]; then
         echo "❌ No execution plan found: $state_file" >&2
-        echo "Run '/architect.implement' first to generate and approve a DAG plan" >&2
+        echo "Run '/architect-implement' first to generate and approve a DAG plan" >&2
         exit 1
     fi
     
@@ -1490,7 +1490,7 @@ action_summarize() {
     # Check if views directory exists and has content
     if [[ ! -d "$views_dir" ]]; then
         echo "❌ Views directory not found: $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     
@@ -1500,7 +1500,7 @@ action_summarize() {
     
     if [[ "$view_count" -eq 0 ]]; then
         echo "❌ No view files found in $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     

--- a/skills/architect/architect-implement/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-implement/scripts/powershell/setup-architect.ps1
@@ -624,12 +624,12 @@ function Invoke-Specify {
     Write-Host "  2. Ask clarifying questions about architecture"
     Write-Host "  3. Create ADRs for each key decision"
     Write-Host "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)"
-    Write-Host "     (ADRs will be moved to .adlc/memory after /architect.implement)"
+    Write-Host "     (ADRs will be moved to .adlc/memory after /architect-implement)"
     if ($Decompose) {
         Write-Host "  5. Organize ADRs by sub-system"
     }
     Write-Host ""
-    Write-Host "After completion, run '/architect.implement' to generate full AD.md"
+    Write-Host "After completion, run '/architect-implement' to generate full AD.md"
     
     if ($Json) {
         @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
@@ -643,7 +643,7 @@ function Invoke-Clarify {
     $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -675,7 +675,7 @@ function Invoke-Implement {
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -808,10 +808,10 @@ function Invoke-Init {
     if ($Decompose) {
         Write-Host "  4. Organize ADRs by sub-system"
     }
-    Write-Host "  5. Auto-trigger /architect.clarify to validate findings"
+    Write-Host "  5. Auto-trigger /architect-clarify to validate findings"
     Write-Host ""
     Write-Host "NOTE: AD.md will NOT be created until ADRs are validated." -ForegroundColor Yellow
-    Write-Host "      After clarification, run /architect.implement to generate AD.md"
+    Write-Host "      After clarification, run /architect-implement to generate AD.md"
     
     if ($Json) {
         @{
@@ -880,7 +880,7 @@ function Invoke-Update {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -920,7 +920,7 @@ function Invoke-Review {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1125,7 +1125,7 @@ function Invoke-PlanDag {
     
     # Check if ADR file exists
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1205,7 +1205,7 @@ function Invoke-ExecuteDag {
     
     # Check if state file exists
     if (-not (Test-Path $stateFile)) {
-        Write-Error "No execution plan found: $stateFile`nRun '/architect.implement' first to generate and approve a DAG plan"
+        Write-Error "No execution plan found: $stateFile`nRun '/architect-implement' first to generate and approve a DAG plan"
         exit 1
     }
     
@@ -1251,7 +1251,7 @@ function Invoke-Summarize {
     
     # Check if views directory exists and has content
     if (-not (Test-Path $viewsDir)) {
-        Write-Error "Views directory not found: $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "Views directory not found: $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     
@@ -1260,7 +1260,7 @@ function Invoke-Summarize {
     $viewCount = $viewFiles.Count
     
     if ($viewCount -eq 0) {
-        Write-Error "No view files found in $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "No view files found in $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     

--- a/skills/architect/architect-implement/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-implement/scripts/powershell/setup-architect.ps1
@@ -449,6 +449,51 @@ function Parse-Views {
     }
 }
 
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+function Get-ArchitectureDiagramFormat {
+    $format = $env:ARCHITECTURE_DIAGRAM_FORMAT
+    if ($format -eq 'mermaid' -or $format -eq 'ascii') {
+        return $format
+    }
+    return 'mermaid'
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation)
+# Returns $true if valid, $false if invalid
+# Args: MermaidCode - Mermaid code string
+function Test-MermaidSyntax {
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$MermaidCode
+    )
+
+    # Check if empty
+    if ([string]::IsNullOrWhiteSpace($MermaidCode)) {
+        return $false
+    }
+
+    # Check for basic Mermaid diagram types
+    if ($MermaidCode -notmatch '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)') {
+        return $false
+    }
+
+    # Check for balanced brackets/parentheses (simplified)
+    $openBrackets = ([regex]::Matches($MermaidCode, '\[')).Count
+    $closeBrackets = ([regex]::Matches($MermaidCode, '\]')).Count
+    $openParens = ([regex]::Matches($MermaidCode, '\(')).Count
+    $closeParens = ([regex]::Matches($MermaidCode, '\)')).Count
+
+    if ($openBrackets -ne $closeBrackets -or $openParens -ne $closeParens) {
+        return $false
+    }
+
+    # Basic syntax passed
+    return $true
+}
+
 # Generate and insert diagrams into architecture.md
 function New-ArchitectureDiagrams {
     param(

--- a/skills/architect/architect-init/scripts/bash/common.sh
+++ b/skills/architect/architect-init/scripts/bash/common.sh
@@ -55,3 +55,46 @@ get_feature_paths() {
     _seed_templates "$repo_root"
     echo "REPO_ROOT=\"$repo_root\""
 }
+
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+get_architecture_diagram_format() {
+    local format="${ARCHITECTURE_DIAGRAM_FORMAT:-mermaid}"
+    if [[ "$format" == "mermaid" || "$format" == "ascii" ]]; then
+        echo "$format"
+    else
+        echo "mermaid"
+    fi
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation).
+# Returns 0 if valid, 1 if invalid.
+# Args: $1 - Mermaid code string
+validate_mermaid_syntax() {
+    local mermaid_code="$1"
+
+    # Check if empty
+    if [[ -z "$mermaid_code" ]]; then
+        return 1
+    fi
+
+    # Check for basic Mermaid diagram types
+    if ! echo "$mermaid_code" | grep -qE '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)'; then
+        return 1
+    fi
+
+    # Check for balanced brackets/parentheses (simplified)
+    local open_brackets close_brackets open_parens close_parens
+    open_brackets=$(echo "$mermaid_code" | grep -o '\[' | wc -l)
+    close_brackets=$(echo "$mermaid_code" | grep -o '\]' | wc -l)
+    open_parens=$(echo "$mermaid_code" | grep -o '(' | wc -l)
+    close_parens=$(echo "$mermaid_code" | grep -o ')' | wc -l)
+
+    if [[ $open_brackets -ne $close_brackets ]] || [[ $open_parens -ne $close_parens ]]; then
+        return 1
+    fi
+
+    # Basic syntax passed
+    return 0
+}

--- a/skills/architect/architect-init/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-init/scripts/bash/setup-architect.sh
@@ -861,12 +861,12 @@ action_specify() {
     echo "  2. Ask clarifying questions about architecture" >&2
     echo "  3. Create ADRs for each key decision" >&2
     echo "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)" >&2
-    echo "     (ADRs will be moved to memory/team after /architect.implement)" >&2
+    echo "     (ADRs will be moved to memory/team after /architect-implement)" >&2
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  5. Organize ADRs by sub-system" >&2
     fi
     echo "" >&2
-    echo "After completion, run '/architect.implement' to generate full AD.md" >&2
+    echo "After completion, run '/architect-implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
@@ -901,7 +901,7 @@ action_clarify() {
             active_scope="memory"
         else
             echo "❌ ADR directory does not exist: $adr_dir" >&2
-            echo "Run '/architect.adlc' or '/architect.init' first" >&2
+            echo "Run '/architect-specify' or '/architect-init' first" >&2
             exit 1
         fi
     fi
@@ -941,7 +941,7 @@ action_implement() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1064,10 +1064,10 @@ action_init() {
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  4. Organize ADRs by sub-system" >&2
     fi
-    echo "  5. Auto-trigger /architect.clarify to validate findings" >&2
+    echo "  5. Auto-trigger /architect-clarify to validate findings" >&2
     echo "" >&2
     echo "NOTE: AD.md will NOT be created until ADRs are validated." >&2
-    echo "      After clarification, run /architect.implement to generate AD.md" >&2
+    echo "      After clarification, run /architect-implement to generate AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
@@ -1127,7 +1127,7 @@ action_map() {
 action_update() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1166,7 +1166,7 @@ action_update() {
 action_review() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1353,7 +1353,7 @@ action_plan_dag() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1447,7 +1447,7 @@ action_execute_dag() {
     # Check if state file exists
     if [[ ! -f "$state_file" ]]; then
         echo "❌ No execution plan found: $state_file" >&2
-        echo "Run '/architect.implement' first to generate and approve a DAG plan" >&2
+        echo "Run '/architect-implement' first to generate and approve a DAG plan" >&2
         exit 1
     fi
     
@@ -1490,7 +1490,7 @@ action_summarize() {
     # Check if views directory exists and has content
     if [[ ! -d "$views_dir" ]]; then
         echo "❌ Views directory not found: $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     
@@ -1500,7 +1500,7 @@ action_summarize() {
     
     if [[ "$view_count" -eq 0 ]]; then
         echo "❌ No view files found in $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     

--- a/skills/architect/architect-init/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-init/scripts/powershell/setup-architect.ps1
@@ -624,12 +624,12 @@ function Invoke-Specify {
     Write-Host "  2. Ask clarifying questions about architecture"
     Write-Host "  3. Create ADRs for each key decision"
     Write-Host "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)"
-    Write-Host "     (ADRs will be moved to .adlc/memory after /architect.implement)"
+    Write-Host "     (ADRs will be moved to .adlc/memory after /architect-implement)"
     if ($Decompose) {
         Write-Host "  5. Organize ADRs by sub-system"
     }
     Write-Host ""
-    Write-Host "After completion, run '/architect.implement' to generate full AD.md"
+    Write-Host "After completion, run '/architect-implement' to generate full AD.md"
     
     if ($Json) {
         @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
@@ -643,7 +643,7 @@ function Invoke-Clarify {
     $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -675,7 +675,7 @@ function Invoke-Implement {
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -808,10 +808,10 @@ function Invoke-Init {
     if ($Decompose) {
         Write-Host "  4. Organize ADRs by sub-system"
     }
-    Write-Host "  5. Auto-trigger /architect.clarify to validate findings"
+    Write-Host "  5. Auto-trigger /architect-clarify to validate findings"
     Write-Host ""
     Write-Host "NOTE: AD.md will NOT be created until ADRs are validated." -ForegroundColor Yellow
-    Write-Host "      After clarification, run /architect.implement to generate AD.md"
+    Write-Host "      After clarification, run /architect-implement to generate AD.md"
     
     if ($Json) {
         @{
@@ -880,7 +880,7 @@ function Invoke-Update {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -920,7 +920,7 @@ function Invoke-Review {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1125,7 +1125,7 @@ function Invoke-PlanDag {
     
     # Check if ADR file exists
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1205,7 +1205,7 @@ function Invoke-ExecuteDag {
     
     # Check if state file exists
     if (-not (Test-Path $stateFile)) {
-        Write-Error "No execution plan found: $stateFile`nRun '/architect.implement' first to generate and approve a DAG plan"
+        Write-Error "No execution plan found: $stateFile`nRun '/architect-implement' first to generate and approve a DAG plan"
         exit 1
     }
     
@@ -1251,7 +1251,7 @@ function Invoke-Summarize {
     
     # Check if views directory exists and has content
     if (-not (Test-Path $viewsDir)) {
-        Write-Error "Views directory not found: $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "Views directory not found: $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     
@@ -1260,7 +1260,7 @@ function Invoke-Summarize {
     $viewCount = $viewFiles.Count
     
     if ($viewCount -eq 0) {
-        Write-Error "No view files found in $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "No view files found in $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     

--- a/skills/architect/architect-init/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-init/scripts/powershell/setup-architect.ps1
@@ -449,6 +449,51 @@ function Parse-Views {
     }
 }
 
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+function Get-ArchitectureDiagramFormat {
+    $format = $env:ARCHITECTURE_DIAGRAM_FORMAT
+    if ($format -eq 'mermaid' -or $format -eq 'ascii') {
+        return $format
+    }
+    return 'mermaid'
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation)
+# Returns $true if valid, $false if invalid
+# Args: MermaidCode - Mermaid code string
+function Test-MermaidSyntax {
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$MermaidCode
+    )
+
+    # Check if empty
+    if ([string]::IsNullOrWhiteSpace($MermaidCode)) {
+        return $false
+    }
+
+    # Check for basic Mermaid diagram types
+    if ($MermaidCode -notmatch '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)') {
+        return $false
+    }
+
+    # Check for balanced brackets/parentheses (simplified)
+    $openBrackets = ([regex]::Matches($MermaidCode, '\[')).Count
+    $closeBrackets = ([regex]::Matches($MermaidCode, '\]')).Count
+    $openParens = ([regex]::Matches($MermaidCode, '\(')).Count
+    $closeParens = ([regex]::Matches($MermaidCode, '\)')).Count
+
+    if ($openBrackets -ne $closeBrackets -or $openParens -ne $closeParens) {
+        return $false
+    }
+
+    # Basic syntax passed
+    return $true
+}
+
 # Generate and insert diagrams into architecture.md
 function New-ArchitectureDiagrams {
     param(

--- a/skills/architect/architect-specify/SKILL.md
+++ b/skills/architect/architect-specify/SKILL.md
@@ -620,8 +620,8 @@ Chosen option: "{title option 1}", because {justification}.
 Recommended next steps:
 
 1. **Review ADRs**: Ensure all decisions are accurate and complete
-2. **Run `/architect.clarify`**: Refine any ambiguous or incomplete ADRs
-3. **Run `/architect.implement`**: Generate full Architecture Description from ADRs
+2. **Run `/architect-clarify`**: Refine any ambiguous or incomplete ADRs
+3. **Run `/architect-implement`**: Generate full Architecture Description from ADRs
 4. **Proceed to features**: Use `/architect-specify` to create new ADRs for additional decisions
 
 ### Context

--- a/skills/architect/architect-specify/scripts/bash/common.sh
+++ b/skills/architect/architect-specify/scripts/bash/common.sh
@@ -55,3 +55,46 @@ get_feature_paths() {
     _seed_templates "$repo_root"
     echo "REPO_ROOT=\"$repo_root\""
 }
+
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+get_architecture_diagram_format() {
+    local format="${ARCHITECTURE_DIAGRAM_FORMAT:-mermaid}"
+    if [[ "$format" == "mermaid" || "$format" == "ascii" ]]; then
+        echo "$format"
+    else
+        echo "mermaid"
+    fi
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation).
+# Returns 0 if valid, 1 if invalid.
+# Args: $1 - Mermaid code string
+validate_mermaid_syntax() {
+    local mermaid_code="$1"
+
+    # Check if empty
+    if [[ -z "$mermaid_code" ]]; then
+        return 1
+    fi
+
+    # Check for basic Mermaid diagram types
+    if ! echo "$mermaid_code" | grep -qE '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)'; then
+        return 1
+    fi
+
+    # Check for balanced brackets/parentheses (simplified)
+    local open_brackets close_brackets open_parens close_parens
+    open_brackets=$(echo "$mermaid_code" | grep -o '\[' | wc -l)
+    close_brackets=$(echo "$mermaid_code" | grep -o '\]' | wc -l)
+    open_parens=$(echo "$mermaid_code" | grep -o '(' | wc -l)
+    close_parens=$(echo "$mermaid_code" | grep -o ')' | wc -l)
+
+    if [[ $open_brackets -ne $close_brackets ]] || [[ $open_parens -ne $close_parens ]]; then
+        return 1
+    fi
+
+    # Basic syntax passed
+    return 0
+}

--- a/skills/architect/architect-specify/scripts/bash/setup-architect.sh
+++ b/skills/architect/architect-specify/scripts/bash/setup-architect.sh
@@ -861,12 +861,12 @@ action_specify() {
     echo "  2. Ask clarifying questions about architecture" >&2
     echo "  3. Create ADRs for each key decision" >&2
     echo "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)" >&2
-    echo "     (ADRs will be moved to memory/team after /architect.implement)" >&2
+    echo "     (ADRs will be moved to memory/team after /architect-implement)" >&2
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  5. Organize ADRs by sub-system" >&2
     fi
     echo "" >&2
-    echo "After completion, run '/architect.implement' to generate full AD.md" >&2
+    echo "After completion, run '/architect-implement' to generate full AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"specify\",\"adr_dir\":\"$adr_dir\",\"context\":\"${ARGS[*]}\",\"decomposition\":\"$DECOMPOSE\"}"
@@ -901,7 +901,7 @@ action_clarify() {
             active_scope="memory"
         else
             echo "❌ ADR directory does not exist: $adr_dir" >&2
-            echo "Run '/architect.adlc' or '/architect.init' first" >&2
+            echo "Run '/architect-specify' or '/architect-init' first" >&2
             exit 1
         fi
     fi
@@ -941,7 +941,7 @@ action_implement() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1064,10 +1064,10 @@ action_init() {
     if [[ "$DECOMPOSE" == "true" ]]; then
         echo "  4. Organize ADRs by sub-system" >&2
     fi
-    echo "  5. Auto-trigger /architect.clarify to validate findings" >&2
+    echo "  5. Auto-trigger /architect-clarify to validate findings" >&2
     echo "" >&2
     echo "NOTE: AD.md will NOT be created until ADRs are validated." >&2
-    echo "      After clarification, run /architect.implement to generate AD.md" >&2
+    echo "      After clarification, run /architect-implement to generate AD.md" >&2
 
     if $JSON_MODE; then
         echo "{\"status\":\"success\",\"action\":\"init\",\"adr_dir\":\"$adr_dir\",\"tech_stack\":\"$tech_stack\",\"existing_docs\":\"$existing_docs\",\"source\":\"brownfield\",\"decomposition\":\"$decompose_status\",\"subsystems\":$subsystems_json}"
@@ -1127,7 +1127,7 @@ action_map() {
 action_update() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1166,7 +1166,7 @@ action_update() {
 action_review() {
     if [[ ! -f "$AD_FILE" ]]; then
         echo "❌ Architecture does not exist: $AD_FILE" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
     
@@ -1353,7 +1353,7 @@ action_plan_dag() {
 
     if [[ "$adr_count" -eq 0 ]]; then
         echo "❌ No ADR drafts found" >&2
-        echo "Run '/architect.adlc' or '/architect.init' first" >&2
+        echo "Run '/architect-specify' or '/architect-init' first" >&2
         exit 1
     fi
 
@@ -1447,7 +1447,7 @@ action_execute_dag() {
     # Check if state file exists
     if [[ ! -f "$state_file" ]]; then
         echo "❌ No execution plan found: $state_file" >&2
-        echo "Run '/architect.implement' first to generate and approve a DAG plan" >&2
+        echo "Run '/architect-implement' first to generate and approve a DAG plan" >&2
         exit 1
     fi
     
@@ -1490,7 +1490,7 @@ action_summarize() {
     # Check if views directory exists and has content
     if [[ ! -d "$views_dir" ]]; then
         echo "❌ Views directory not found: $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     
@@ -1500,7 +1500,7 @@ action_summarize() {
     
     if [[ "$view_count" -eq 0 ]]; then
         echo "❌ No view files found in $views_dir" >&2
-        echo "Run '/architect.implement' to generate views first" >&2
+        echo "Run '/architect-implement' to generate views first" >&2
         exit 1
     fi
     

--- a/skills/architect/architect-specify/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-specify/scripts/powershell/setup-architect.ps1
@@ -624,12 +624,12 @@ function Invoke-Specify {
     Write-Host "  2. Ask clarifying questions about architecture"
     Write-Host "  3. Create ADRs for each key decision"
     Write-Host "  4. Save decisions to .adlc/drafts/adr/ADR-{NNN}.md (Proposed status)"
-    Write-Host "     (ADRs will be moved to .adlc/memory after /architect.implement)"
+    Write-Host "     (ADRs will be moved to .adlc/memory after /architect-implement)"
     if ($Decompose) {
         Write-Host "  5. Organize ADRs by sub-system"
     }
     Write-Host ""
-    Write-Host "After completion, run '/architect.implement' to generate full AD.md"
+    Write-Host "After completion, run '/architect-implement' to generate full AD.md"
     
     if ($Json) {
         @{status="success"; action="specify"; adr_dir=$adrDir; context=($contextArgs -join " "); decomposition=$Decompose} | ConvertTo-Json
@@ -643,7 +643,7 @@ function Invoke-Clarify {
     $adrDir = Join-Path $repoRoot ".adlc\memory\adr"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -675,7 +675,7 @@ function Invoke-Implement {
     $adTemplate = Join-Path $repoRoot ".adlc\templates\AD-template.md"
     
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -808,10 +808,10 @@ function Invoke-Init {
     if ($Decompose) {
         Write-Host "  4. Organize ADRs by sub-system"
     }
-    Write-Host "  5. Auto-trigger /architect.clarify to validate findings"
+    Write-Host "  5. Auto-trigger /architect-clarify to validate findings"
     Write-Host ""
     Write-Host "NOTE: AD.md will NOT be created until ADRs are validated." -ForegroundColor Yellow
-    Write-Host "      After clarification, run /architect.implement to generate AD.md"
+    Write-Host "      After clarification, run /architect-implement to generate AD.md"
     
     if ($Json) {
         @{
@@ -880,7 +880,7 @@ function Invoke-Update {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -920,7 +920,7 @@ function Invoke-Review {
     param($repoRoot, $architectureFile)
     
     if (-not (Test-Path $architectureFile)) {
-        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "Architecture does not exist: $architectureFile`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1125,7 +1125,7 @@ function Invoke-PlanDag {
     
     # Check if ADR file exists
     if (-not (Test-Path $adrDir)) {
-        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect.adlc' or '/architect.init' first"
+        Write-Error "ADR drafts file does not exist: $adrDir`nRun '/architect-specify' or '/architect-init' first"
         exit 1
     }
     
@@ -1205,7 +1205,7 @@ function Invoke-ExecuteDag {
     
     # Check if state file exists
     if (-not (Test-Path $stateFile)) {
-        Write-Error "No execution plan found: $stateFile`nRun '/architect.implement' first to generate and approve a DAG plan"
+        Write-Error "No execution plan found: $stateFile`nRun '/architect-implement' first to generate and approve a DAG plan"
         exit 1
     }
     
@@ -1251,7 +1251,7 @@ function Invoke-Summarize {
     
     # Check if views directory exists and has content
     if (-not (Test-Path $viewsDir)) {
-        Write-Error "Views directory not found: $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "Views directory not found: $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     
@@ -1260,7 +1260,7 @@ function Invoke-Summarize {
     $viewCount = $viewFiles.Count
     
     if ($viewCount -eq 0) {
-        Write-Error "No view files found in $viewsDir`nRun '/architect.implement' to generate views first"
+        Write-Error "No view files found in $viewsDir`nRun '/architect-implement' to generate views first"
         exit 1
     }
     

--- a/skills/architect/architect-specify/scripts/powershell/setup-architect.ps1
+++ b/skills/architect/architect-specify/scripts/powershell/setup-architect.ps1
@@ -449,6 +449,51 @@ function Parse-Views {
     }
 }
 
+# Get architecture diagram format (mermaid or ascii).
+# Override via ARCHITECTURE_DIAGRAM_FORMAT env var; defaults to "mermaid".
+# Invalid values fall back to "mermaid".
+function Get-ArchitectureDiagramFormat {
+    $format = $env:ARCHITECTURE_DIAGRAM_FORMAT
+    if ($format -eq 'mermaid' -or $format -eq 'ascii') {
+        return $format
+    }
+    return 'mermaid'
+}
+
+# Validate Mermaid diagram syntax (lightweight regex validation)
+# Returns $true if valid, $false if invalid
+# Args: MermaidCode - Mermaid code string
+function Test-MermaidSyntax {
+    param(
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$MermaidCode
+    )
+
+    # Check if empty
+    if ([string]::IsNullOrWhiteSpace($MermaidCode)) {
+        return $false
+    }
+
+    # Check for basic Mermaid diagram types
+    if ($MermaidCode -notmatch '^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline)') {
+        return $false
+    }
+
+    # Check for balanced brackets/parentheses (simplified)
+    $openBrackets = ([regex]::Matches($MermaidCode, '\[')).Count
+    $closeBrackets = ([regex]::Matches($MermaidCode, '\]')).Count
+    $openParens = ([regex]::Matches($MermaidCode, '\(')).Count
+    $closeParens = ([regex]::Matches($MermaidCode, '\)')).Count
+
+    if ($openBrackets -ne $closeBrackets -or $openParens -ne $closeParens) {
+        return $false
+    }
+
+    # Basic syntax passed
+    return $true
+}
+
 # Generate and insert diagrams into architecture.md
 function New-ArchitectureDiagrams {
     param(

--- a/skills/product/product-analyze/SKILL.md
+++ b/skills/product/product-analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-analyze
-description: Read-only analysis of PDR↔PRD consistency, PDR quality, cross-PDR conflicts, and staleness. Outputs a structured markdown report with severity-assigned findings. Use after /product.implement or periodically to detect drift.
+description: Read-only analysis of PDR↔PRD consistency, PDR quality, cross-PDR conflicts, and staleness. Outputs a structured markdown report with severity-assigned findings. Use after /product-implement or periodically to detect drift.
 disable-model-invocation: true
 ---
 
@@ -20,14 +20,14 @@ Performs **read-only** product consistency analysis:
 
 ## When to use
 
-- After `/product.implement` to validate generated PRD
-- After `/product.clarify` to verify refinements
+- After `/product-implement` to validate generated PRD
+- After `/product-clarify` to verify refinements
 - Before feature development to ensure product is solid
 - Periodically to detect drift as product evolves
 
 ## When NOT to use
 
-- No product artifacts exist (use `/product.init` or `/product.specify` first)
+- No product artifacts exist (use `/product-init` or `/product-specify` first)
 - You want to modify files (this is analysis-only)
 
 ## Execution Steps
@@ -148,13 +148,13 @@ For each PDR, check if decision appears in PRD:
 
 ### Next Actions
 - **CRITICAL issues**: Resolve constitution violations before proceeding
-  - Command: `/product.clarify`
+  - Command: `/product-clarify`
 - **HIGH PDR quality**: Address missing alternatives and consequences
-  - Command: `/product.clarify`
+  - Command: `/product-clarify`
 - **PDR→PRD drift**: Update PRD to reflect PDR decisions
-  - Command: `/product.implement --update`
+  - Command: `/product-implement --update`
 - **PRD→PDR drift**: Create missing PDRs
-  - Command: `/product.specify` or `/product.init`
+  - Command: `/product-specify` or `/product-init`
 ```
 
 ## Key Rules

--- a/skills/product/product-clarify/SKILL.md
+++ b/skills/product/product-clarify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-clarify
-description: Refine and validate Product Decision Records through targeted clarification questions. Review PDR completeness, detect conflicts, approve decisions, and update status to Accepted. Use before /product.implement.
+description: Refine and validate Product Decision Records through targeted clarification questions. Review PDR completeness, detect conflicts, approve decisions, and update status to Accepted. Use before /product-implement.
 disable-model-invocation: true
 ---
 
@@ -16,14 +16,14 @@ Reviews existing PDRs for quality gaps, asks targeted clarification questions, a
 
 ## When to use
 
-- After `/product.specify` or `/product.init` to refine initial PDRs
-- Before `/product.implement` to approve PDRs (required — implement skips non-Accepted)
+- After `/product-specify` or `/product-init` to refine initial PDRs
+- Before `/product-implement` to approve PDRs (required — implement skips non-Accepted)
 - Periodic PDR review before milestones
 - Resolving inconsistency flags from cross-feature-area analysis
 
 ## When NOT to use
 
-- No PDRs exist (use `/product.specify` or `/product.init` first)
+- No PDRs exist (use `/product-specify` or `/product-init` first)
 
 ## Execution Steps
 
@@ -165,7 +165,7 @@ D. Remove PDR — Delete and follow constitution
 
 ### Phase 8: PDR Approval ⭐
 
-**Critical**: `/product.implement` only processes PDRs with **Accepted** status.
+**Critical**: `/product-implement` only processes PDRs with **Accepted** status.
 
 ```markdown
 ## PDR Approval ⭐
@@ -204,7 +204,7 @@ Change [N] PDRs to Accepted?
 - Accepted PDRs: [N]
 - Pending: [N]
 
-Run `/product.implement` to generate PRD.md.
+Run `/product-implement` to generate PRD.md.
 ```
 
 ## Key Rules

--- a/skills/product/product-implement/SKILL.md
+++ b/skills/product/product-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-implement
-description: Generate a full Product Requirements Document (PRD.md) from accepted PDRs using multi-agent DAG orchestration. Reads individual PDR files, generates PRD sections from templates, validates output, and promotes accepted PDRs to memory. Use after /product.clarify.
+description: Generate a full Product Requirements Document (PRD.md) from accepted PDRs using multi-agent DAG orchestration. Reads individual PDR files, generates PRD sections from templates, validates output, and promotes accepted PDRs to memory. Use after /product-clarify.
 disable-model-invocation: true
 ---
 
@@ -21,13 +21,13 @@ Transforms **accepted PDRs** into a comprehensive, self-contained `PRD.md` using
 
 ## When to use
 
-- After `/product.clarify` has approved PDRs
-- After `/product.init` to document existing product
+- After `/product-clarify` has approved PDRs
+- After `/product-init` to document existing product
 - PDR updates requiring PRD regeneration
 
 ## When NOT to use
 
-- No Accepted PDRs (run `/product.clarify` first)
+- No Accepted PDRs (run `/product-clarify` first)
 - Minor PRD edits (edit `PRD.md` directly)
 
 ## Pre-Flight Validation
@@ -39,7 +39,7 @@ Transforms **accepted PDRs** into a comprehensive, self-contained `PRD.md` using
    - If **zero**: STOP and output:
      ```
      Cannot proceed: No Accepted PDRs found.
-     Run /product.clarify to review and approve PDRs first.
+     Run /product-clarify to review and approve PDRs first.
      ```
    - If ≥1: Proceed
 

--- a/skills/product/product-implement/templates/subagents/synthesis-prompt.md
+++ b/skills/product/product-implement/templates/subagents/synthesis-prompt.md
@@ -69,7 +69,7 @@ For each inconsistency, create a flag (not a separate PDR):
   "affected_areas": ["core", "business"],
   "conflicting_patterns": ["P003", "P012"],
   "description": "Core prioritizes 'ease of use' while Business prioritizes 'revenue optimization' for same user journey",
-  "recommended_action": "Run /product.clarify to align priorities",
+  "recommended_action": "Run /product-clarify to align priorities",
   "pdr_to_attach": "PDR-003"
 }
 ```
@@ -93,7 +93,7 @@ Create PDRs for:
 {YYYY-MM-DD}
 
 ### Source
-Cross-feature-area synthesis via /product.init
+Cross-feature-area synthesis via /product-init
 
 ### Category
 Problem | Persona | Scope | Metric | Prioritization | Business Model | Feature | NFR | Milestone
@@ -120,7 +120,7 @@ Problem | Persona | Scope | Metric | Prioritization | Business Model | Feature |
 - **Severity**: Medium
 - **Issue**: Core area prioritizes "ease of use" while Business area prioritizes "revenue optimization"
 - **Affected PDRs**: PDR-003, PDR-012
-- **Recommended Action**: Run `/product.clarify` to align priorities across areas
+- **Recommended Action**: Run `/product-clarify` to align priorities across areas
 - **Resolution**: Pending
 
 ### Context
@@ -163,14 +163,14 @@ Create synthesis summary:
 ### Inconsistencies Requiring Clarification
 | Flag ID | Type | Areas | Severity | Recommended Action |
 |---------|------|-------|----------|-------------------|
-| FLG-001 | Priority Conflict | core, business | Medium | Run /product.clarify |
-| FLG-002 | Metric Definition | business, growth | Low | Run /product.clarify |
+| FLG-001 | Priority Conflict | core, business | Medium | Run /product-clarify |
+| FLG-002 | Metric Definition | business, growth | Low | Run /product-clarify |
 
 ### Next Steps
 1. Review PDRs with inconsistency flags
-2. Run `/product.clarify` to resolve flagged conflicts
+2. Run `/product-clarify` to resolve flagged conflicts
 3. Update PDRs with resolutions
-4. Run `/product.implement` to generate PRD
+4. Run `/product-implement` to generate PRD
 ```
 
 ## Output Format

--- a/skills/product/product-init/SKILL.md
+++ b/skills/product/product-init/SKILL.md
@@ -25,8 +25,8 @@ Reverse-engineers product decisions from an **existing product** using a **three
 
 ## When NOT to use
 
-- New product (use `/product.specify` instead)
-- Minor PDR updates (use `/product.clarify` instead)
+- New product (use `/product-specify` instead)
+- Minor PDR updates (use `/product-clarify` instead)
 
 ## Execution Steps
 
@@ -266,8 +266,8 @@ Generate `{REPO_ROOT}/.adlc/drafts/pdr/pdr.md` from all `PDR-*.md` files:
 
 ### Next Steps
 1. Review PDRs: `{REPO_ROOT}/.adlc/drafts/pdr/`
-2. **Resolve inconsistencies**: Run `/product.clarify`
-3. Generate PRD: Run `/product.implement`
+2. **Resolve inconsistencies**: Run `/product-clarify`
+3. Generate PRD: Run `/product-implement`
 ```
 
 ## PDR Numbering Rules

--- a/skills/product/product-roadmap/SKILL.md
+++ b/skills/product/product-roadmap/SKILL.md
@@ -28,8 +28,8 @@ A milestone is **live** only when all four layers are green. Anything less gets 
 
 ## When NOT to use
 
-- No PDRs exist (use `/product.specify` or `/product.init` first)
-- You want to create PDRs (use `/product.specify`)
+- No PDRs exist (use `/product-specify` or `/product-init` first)
+- You want to create PDRs (use `/product-specify`)
 
 ## Execution Steps
 
@@ -102,7 +102,7 @@ For each feature PDR in a milestone, verify code evidence:
 - Optionally grep for title keywords in the codebase
 - Lower confidence — reported as "heuristic evidence"
 
-**Hand-off rule**: deep re-discovery is NOT roadmap's job. When evidence is missing/stale on a "Completed" item, the report says: *"⚠️ Code evidence missing — run /product.init to re-discover"*. Roadmap does lightweight checks; full discovery stays in init.
+**Hand-off rule**: deep re-discovery is NOT roadmap's job. When evidence is missing/stale on a "Completed" item, the report says: *"⚠️ Code evidence missing — run /product-init to re-discover"*. Roadmap does lightweight checks; full discovery stays in init.
 
 ### Phase D: Gate Rollup
 
@@ -149,7 +149,7 @@ Tracker: github.com/org/repo/milestone/3 (native: 67% closed, due Sep 5)
 | Condition | Warning |
 |---|---|
 | All features Completed but issues still open | "⚠️ Features claim complete but N issues still open — execution not finished" |
-| All issues closed but code evidence missing | "⚠️ Issues closed but code evidence missing — verify with /product.init" |
+| All issues closed but code evidence missing | "⚠️ Issues closed but code evidence missing — verify with /product-init" |
 | All features done but gates pending | "⚠️ Features done, milestone NOT live — N gates pending: [list]" |
 | Milestone marked Completed but no gates section | "⚠️ Milestone has no gates — consider adding acceptance criteria" |
 
@@ -222,7 +222,7 @@ When querying issue states, detect available tools in this order:
 
 ### Status Updates
 - `--update` blocks on pending issues/gates/evidence unless explicit override
-- Only update PDR status, not PRD directly — `/product.implement` regenerates PRD
+- Only update PDR status, not PRD directly — `/product-implement` regenerates PRD
 - Preserve all other PDR fields when updating status
 
 ### Backward Compatibility

--- a/skills/product/product-specify/SKILL.md
+++ b/skills/product/product-specify/SKILL.md
@@ -23,8 +23,8 @@ Transforms a high-level product idea into documented Product Decision Records (P
 
 ## When NOT to use
 
-- Existing product (use `/product.init` instead)
-- Minor PDR updates (use `/product.clarify` instead)
+- Existing product (use `/product-init` instead)
+- Minor PDR updates (use `/product-clarify` instead)
 
 ## Execution Steps
 
@@ -232,8 +232,8 @@ YYYY-MM-DD
 | 3 | Business | PDR-004: Pricing Model, PDR-005: Payment Integration |
 
 ### Next Steps
-1. Review PDRs with /product.clarify
-2. Generate PRD.md with /product.implement
+1. Review PDRs with /product-clarify
+2. Generate PRD.md with /product-implement
 ```
 
 ## PDR Numbering Rules
@@ -284,7 +284,7 @@ YYYY-MM-DD
 
 ## Red Flags
 
-- **Generating PRD before PDRs are accepted** — `/product.implement` requires Accepted status; Proposed PDRs will be skipped.
+- **Generating PRD before PDRs are accepted** — `/product-implement` requires Accepted status; Proposed PDRs will be skipped.
 - **Skipping the constitution check** — misaligned decisions propagate into the PRD and become expensive to fix.
 - **No alternatives documented** — a PDR without alternatives is a statement, not a decision.
 

--- a/skills/product/product-templates/prd-template.md
+++ b/skills/product/product-templates/prd-template.md
@@ -732,7 +732,7 @@ gantt
     [Milestone 2] :milestone, m2, [DATE], 0d
 ```
 
-> **Sync with external tools**: Run `/product.roadmap --sync` to pull milestones from GitHub/GitLab/Jira/Linear
+> **Sync with external tools**: Run `/product-roadmap --sync` to pull milestones from GitHub/GitLab/Jira/Linear
 
 <!-- Generated from Milestone PDRs -->
 

--- a/tests/unit/test_setup_scripts.py
+++ b/tests/unit/test_setup_scripts.py
@@ -69,3 +69,53 @@ def test_bash_setup_script_execution(sandbox_project, script_path):
         assert resolved_path in [sandbox_project.resolve(), ROOT.resolve()], (
             f"REPO_ROOT mismatch in {script_path}. Expected {sandbox_project} or {ROOT}, got {data['REPO_ROOT']}"
         )
+
+
+# --- Static guards: architect diagram helpers --------------------------------
+# Regression guard for the "get_architecture_diagram_format: command not found"
+# incident (line 761 of setup-architect.sh): these functions are called by
+# generate_and_insert_diagrams / New-ArchitectureDiagrams but were never ported
+# from the spec-kit common.sh/common.ps1 into the adlc bundled scripts.
+
+ARCHITECT_BASH_COMMONS = sorted(ROOT.glob("skills/architect/architect-*/scripts/bash/common.sh"))
+ARCHITECT_PS1_SETUPS = sorted(ROOT.glob("skills/architect/architect-*/scripts/powershell/setup-architect.ps1"))
+
+
+def test_architect_common_sh_defines_diagram_functions():
+    """Every architect bash common.sh must define the diagram helper functions."""
+    assert len(ARCHITECT_BASH_COMMONS) == 5, f"Expected 5 architect common.sh files, found {len(ARCHITECT_BASH_COMMONS)}"
+    for common_sh in ARCHITECT_BASH_COMMONS:
+        content = common_sh.read_text(encoding="utf-8")
+        assert "get_architecture_diagram_format()" in content, (
+            f"{common_sh.relative_to(ROOT)} missing get_architecture_diagram_format()"
+        )
+        assert "validate_mermaid_syntax()" in content, (
+            f"{common_sh.relative_to(ROOT)} missing validate_mermaid_syntax()"
+        )
+
+
+def test_architect_ps1_defines_diagram_functions():
+    """Every architect setup-architect.ps1 must define the diagram helper functions."""
+    assert len(ARCHITECT_PS1_SETUPS) == 5, f"Expected 5 architect PS1 files, found {len(ARCHITECT_PS1_SETUPS)}"
+    for ps1 in ARCHITECT_PS1_SETUPS:
+        content = ps1.read_text(encoding="utf-8")
+        assert "function Get-ArchitectureDiagramFormat" in content, (
+            f"{ps1.relative_to(ROOT)} missing Get-ArchitectureDiagramFormat"
+        )
+        assert "function Test-MermaidSyntax" in content, (
+            f"{ps1.relative_to(ROOT)} missing Test-MermaidSyntax"
+        )
+
+
+def test_architect_bash_common_sh_copies_identical():
+    """The 5 architect common.sh files must stay byte-identical (shared contract)."""
+    contents = {p: p.read_bytes() for p in ARCHITECT_BASH_COMMONS}
+    unique = set(contents.values())
+    assert len(unique) == 1, "architect common.sh files have diverged — keep all 5 copies identical"
+
+
+def test_architect_ps1_setup_copies_identical():
+    """The 5 architect setup-architect.ps1 files must stay byte-identical (shared contract)."""
+    contents = {p: p.read_bytes() for p in ARCHITECT_PS1_SETUPS}
+    unique = set(contents.values())
+    assert len(unique) == 1, "architect setup-architect.ps1 files have diverged — keep all 5 copies identical"

--- a/tests/unit/test_setup_scripts.py
+++ b/tests/unit/test_setup_scripts.py
@@ -119,3 +119,21 @@ def test_architect_ps1_setup_copies_identical():
     contents = {p: p.read_bytes() for p in ARCHITECT_PS1_SETUPS}
     unique = set(contents.values())
     assert len(unique) == 1, "architect setup-architect.ps1 files have diverged — keep all 5 copies identical"
+
+
+def test_no_dot_notation_skill_references():
+    """Skills must hand over to hyphenated command names (/architect-init), never
+    spec-kit dot-notation (/architect.init, /architect.adlc, /product.clarify).
+    The .opencode/commands/ files are hyphenated, so dot-notation references are dead links."""
+    import re
+    pattern = re.compile(
+        r"/(architect|product|levelup|evals|team)\."
+        r"(init|specify|clarify|implement|analyze|roadmap|validate|publish|adlc)\b"
+    )
+    offenders = []
+    for ext in ("*.md", "*.sh", "*.ps1"):
+        for f in ROOT.glob(f"skills/**/{ext}"):
+            for lineno, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+                if pattern.search(line):
+                    offenders.append(f"{f.relative_to(ROOT)}:{lineno}: {line.strip()[:100]}")
+    assert not offenders, "Dot-notation skill references found (use hyphens):\n" + "\n".join(offenders[:20])


### PR DESCRIPTION
## Problem

```
Views: context functional information development deployment
setup-architect.sh: line 761: get_architecture_diagram_format: command not found
```

The architect setup scripts were ported from spec-kit, where `get_architecture_diagram_format()` and `validate_mermaid_syntax()` (bash) / `Get-ArchitectureDiagramFormat` and `Test-MermaidSyntax` (PowerShell) were defined in spec-kit's large `common.sh`/`common.ps1`. The adlc bundled `common.sh` is a minimal 57-line file that never included them, so any action calling `generate_and_insert_diagrams` (`update`, `map`) crashed at line 761.

Same bug in PowerShell: `Get-ArchitectureDiagramFormat` (line 463) and `Test-MermaidSyntax` (line 498) were called but never defined (no common.ps1 exists).

## Fix

| File | Change |
|------|--------|
| `skills/architect/architect-*/scripts/bash/common.sh` (×5, identical) | Add `get_architecture_diagram_format` + `validate_mermaid_syntax` |
| `skills/architect/architect-*/scripts/powershell/setup-architect.ps1` (×5, identical) | Add `Get-ArchitectureDiagramFormat` + `Test-MermaidSyntax` |

The diagram format is overridable via the `ARCHITECTURE_DIAGRAM_FORMAT` env var (`mermaid`|`ascii`, default `mermaid`), matching the existing `ARCHITECTURE_VIEWS` env var pattern instead of spec-kit's config-file lookup.

## Tests

- `test_architect_common_sh_defines_diagram_functions` — static guard, all 5 bash copies define both functions
- `test_architect_ps1_defines_diagram_functions` — static guard, all 5 PS1 copies define both functions
- `test_architect_bash_common_sh_copies_identical` — drift guard, locks 5 bash copies byte-identical
- `test_architect_ps1_setup_copies_identical` — drift guard, locks 5 PS1 copies byte-identical

## Verification

- [x] `setup-architect.sh update` completes diagram generation (mermaid default) — was the exact failing path
- [x] `ARCHITECTURE_DIAGRAM_FORMAT=ascii` → ascii path works
- [x] Invalid env value → falls back to mermaid
- [x] `validate_mermaid_syntax` accepts valid mermaid, rejects invalid/empty
- [x] All **98 tests pass** (94 existing + 4 new guards)

**Note**: users with installed copies under `.agents/skills/architect-init/` need to re-install the skill to pick up this fix.