### PR TITLE
feat(ci): auto-tag release on PR merge to main; fix product-implement validate-prd.sh

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,96 @@
+name: Auto-Tag Release
+
+# Tags new CHANGELOG versions automatically after a PR merges to main.
+# Compares the versions declared in CHANGELOG.md against existing
+# `adlc-team-skills-v*` tags and creates annotated tags for any NEW untagged
+# versions at the merge commit. Each pushed tag then triggers the existing
+# Release workflow, which validates and creates the GitHub release.
+#
+# Security: this is the ONLY workflow that carries contents: write, and it
+# only runs on push to main (never on pull_request), so the elevated token
+# is never exposed to untrusted PR code. test.yml stays contents: read.
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    # Only tag on the canonical repo, never on forks.
+    if: github.repository == 'tikalk/adlc-team-skills'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find new untagged CHANGELOG versions
+        id: versions
+        run: |
+          # All semver versions declared in CHANGELOG.md, newest first.
+          mapfile -t declared < <(grep -oP '^## \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md)
+
+          if [[ ${#declared[@]} -eq 0 ]]; then
+            echo "ERROR: no version headers (## [X.Y.Z]) found in CHANGELOG.md"
+            exit 1
+          fi
+
+          # Highest already-tagged version, if any.
+          latest_tagged="$(git tag -l 'adlc-team-skills-v*' \
+            | sed 's/^adlc-team-skills-v//' | sort -V | tail -n1 || true)"
+
+          # Only versions NEWER than the latest tag qualify for auto-tagging.
+          # Older untagged versions (pre-existing gaps like 0.1.0) must be
+          # tagged manually at their original commit, not at the merge commit.
+          candidates=()
+          for version in "${declared[@]}"; do
+            if [[ -z "$latest_tagged" ]] \
+              || [[ "$(printf '%s\n%s' "$version" "$latest_tagged" | sort -V | tail -n1)" == "$version" ]]; then
+              candidates+=("$version")
+            fi
+          done
+
+          # Drop already-tagged versions.
+          untagged=()
+          for version in "${candidates[@]}"; do
+            if ! git rev-parse -q --verify "refs/tags/adlc-team-skills-v${version}" >/dev/null; then
+              untagged+=("$version")
+            fi
+          done
+
+          if [[ ${#untagged[@]} -eq 0 ]]; then
+            echo "No new versions to tag (latest tagged: ${latest_tagged:-none})."
+            echo "untagged=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "New versions to tag at ${GITHUB_SHA}:"
+          for version in "${untagged[@]}"; do
+            echo "  - $version"
+          done
+
+          echo "untagged=${untagged[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tags
+        if: steps.versions.outputs.untagged != ''
+        run: |
+          for version in ${{ steps.versions.outputs.untagged }}; do
+            # Validate semver shape before tagging.
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+              || { echo "ERROR: not semver: $version"; exit 1; }
+
+            tag="adlc-team-skills-v${version}"
+            # Idempotency guard: skip if a concurrent run already tagged it.
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "Tag already exists locally, skipping: $tag"
+              continue
+            fi
+
+            echo "Creating tag: $tag at ${GITHUB_SHA}"
+            git tag -a "$tag" -m "v${version}" "$GITHUB_SHA"
+            git push origin "$tag"
+            echo "Pushed: $tag"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2026-08-09
+
+### Added
+
+- **Auto-tag release on PR merge** (`.github/workflows/auto-tag.yml`, `RELEASE.md`): new GitHub Actions workflow that runs on every push to `main`, parses the `## [X.Y.Z]` headers from `CHANGELOG.md`, and creates annotated `adlc-team-skills-v*` tags for every new untagged version at the merge commit. Each pushed tag then triggers the existing Release workflow, which creates the GitHub release — no manual tagging needed after a PR merges. Multi-version merge commits get one tag per new CHANGELOG version. The workflow carries `contents: write` but only runs on push to `main` (never on `pull_request`), so the elevated token is never exposed to untrusted PR code; `test.yml` remains `contents: read`. Versions older than the latest existing tag are deliberately skipped (historical gaps like `0.1.0` must still be tagged manually at their original commit).
+
 ## [0.24.0] - 2026-08-08
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,22 +14,30 @@ Examples: `adlc-team-skills-v0.9.0`, `adlc-team-skills-v1.0.0`
 
 1. **Update `CHANGELOG.md`** — add the new version entry at the top with a date and Added/Changed/Fixed/Removed sections
 2. **Commit and push** — all changes committed and pushed to `main`
-3. **Create annotated tag** at the release commit:
-   ```bash
-   git tag adlc-team-skills-vX.Y.Z -m "vX.Y.Z"
-   ```
-4. **Push the tag**:
-   ```bash
-   git push origin adlc-team-skills-vX.Y.Z
-   ```
-5. **Create GitHub release** with the CHANGELOG section as notes:
-   ```bash
-   awk '/^## \[X.Y.Z\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
-     | gh release create adlc-team-skills-vX.Y.Z --title "adlc-team-skills vX.Y.Z" --notes-file - --latest
-   ```
-6. **Verify**: `gh release list` shows the new release as Latest, notes render correctly
+3. **Merge the PR** — the **Auto-Tag Release** workflow creates the annotated
+   tag at the merge commit automatically (see below). Manual tagging is only
+   needed for pre-existing untagged versions (e.g. old gaps like `0.1.0`).
+4. **Verify**: `gh release list` shows the new release as Latest, notes render correctly
 
-## Automated release
+## Automated tagging (after PR merge)
+
+The **Auto-Tag Release** GitHub Actions workflow runs on every push to `main`:
+
+1. Parses all `## [X.Y.Z]` headers from `CHANGELOG.md`.
+2. Compares them against existing `adlc-team-skills-v*` tags.
+3. Creates annotated tags for every **new** untagged version **newer than the
+   latest existing tag**, pointing at the merge commit.
+4. Each pushed tag triggers the **Release** workflow, which validates the
+   CHANGELOG entry, confirms the commit is on `main`, extracts the notes, and
+   creates the release with `--latest` — automatically.
+
+Multi-version commits are handled: if one merge commit adds several new
+CHANGELOG versions, each version gets its own tag at that commit.
+
+## Manual release
+
+If you prefer to tag explicitly (or are tagging a pre-existing untagged
+version that the workflow deliberately skips):
 
 1. Update `CHANGELOG.md` with the new version entry and commit/push to `main`.
 2. Tag and push:
@@ -77,7 +85,10 @@ gh release create adlc-team-skills-vX.Y.Z --title "adlc-team-skills vX.Y.Z" --no
 
 ### Missing tag for old version
 
-If a version has a CHANGELOG entry but no tag:
+The Auto-Tag Release workflow deliberately only tags versions **newer than the
+latest existing tag**, so it will never auto-tag a historical gap (it would
+point at the wrong commit). If an old version has a CHANGELOG entry but no
+tag, tag its original release commit manually:
 
 ```bash
 # Tag the release commit retroactively
@@ -106,5 +117,6 @@ awk '/^## \[X.Y.Z\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
 
 - One tag per CHANGELOG version entry
 - If multiple CHANGELOG versions are bundled into a single commit, tag the same commit for each version
+- The Auto-Tag Release workflow tags every new version in CHANGELOG.md on each push to `main`; it is a no-op when nothing is untagged
 - Always mark the latest release with `--latest`
 - Release notes come from the CHANGELOG section, not the commit message

--- a/skills/product/product-implement/scripts/bash/validate-prd.sh
+++ b/skills/product/product-implement/scripts/bash/validate-prd.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# PRD Validation Script v1.5.6
+# PRD Validation Script v1.5.7
+# v1.5.7: fix set -e abort on ((VAR++)) from 0 (pre-increment); fix REQ regex to match '- **REQ-NNN:**' canonical format; fix BRE \| alternation in REQUIRED_SECTIONS used with grep -E
 # Validates PRD compliance with product extension standards
 # Checks: Section 1 = Doc Info, in-section diagrams, Mermaid, business sections, self-contained, PDR traceability
 # Usage: validate-prd.sh [PRD_FILE] [--strict|--warn]
@@ -62,7 +63,7 @@ if [[ ! -f "$PRD_FILE" ]]; then
 fi
 
 echo -e "${BLUE}🔍 Validating PRD: $PRD_FILE${NC}"
-echo -e "${BLUE}Extension Version: 1.5.6 | Mode: $([ "$STRICT_MODE" == true ] && echo "STRICT" || echo "WARN")${NC}"
+echo -e "${BLUE}Extension Version: 1.5.7 | Mode: $([ "$STRICT_MODE" == true ] && echo "STRICT" || echo "WARN")${NC}"
 echo "================================================"
 
 # Function to report success
@@ -77,13 +78,13 @@ warn() {
     else
         echo -e "${RED}✗ ERROR${NC}: $1"
     fi
-    ((WARNINGS++))
+    ((++WARNINGS))
 }
 
 # Function to report error
 fail() {
     echo -e "${RED}✗ FAIL${NC}: $1"
-    ((ERRORS++))
+    ((++ERRORS))
 }
 
 # ============================================
@@ -221,7 +222,7 @@ echo ""
 echo -e "${BLUE}[5/9] Checking PDR traceability...${NC}"
 
 # Count requirements
-REQ_COUNT=$(grep -cE '^\s*\*\*REQ-[0-9]+\*\*' "$PRD_FILE" || true)
+REQ_COUNT=$(grep -cE '^\s*[-*+]?\s*\*\*REQ-[0-9]+:?\*\*' "$PRD_FILE" || true)
 # Count PDR references
 PDR_REFS=$(grep -cE 'PDR-[0-9]+' "$PRD_FILE" || true)
 
@@ -229,14 +230,14 @@ if [[ $REQ_COUNT -gt 0 ]]; then
     pass "Found $REQ_COUNT requirements (REQ-XXX format)"
     
     # Check if requirements have PDR references
-    REQ_LINES=$(grep -n 'REQ-[0-9]' "$PRD_FILE" | cut -d: -f1)
+    REQ_LINES=$(grep -nE '^\s*[-*+]?\s*\*\*REQ-[0-9]+:?\*\*' "$PRD_FILE" | cut -d: -f1)
     REQ_WITH_PDR=0
     
     for line_num in $REQ_LINES; do
         # Check next 3 lines for PDR reference
         CONTEXT=$(sed -n "${line_num},$((line_num + 3))p" "$PRD_FILE")
         if echo "$CONTEXT" | grep -qE 'PDR-[0-9]+'; then
-            ((REQ_WITH_PDR++))
+            ((++REQ_WITH_PDR))
         fi
     done
     
@@ -259,23 +260,23 @@ echo -e "${BLUE}[6/9] Checking required sections...${NC}"
 REQUIRED_SECTIONS=(
     "1.*Document Information"
     "2.*Overview"
-    "3.*Problem\|3.*The Problem"
-    "4.*Goals\|4.*Objectives"
-    "5.*Metrics\|5.*Success Metrics"
+    "3.*Problem|3.*The Problem"
+    "4.*Goals|4.*Objectives"
+    "5.*Metrics|5.*Success Metrics"
     "6.*Personas"
-    "7.*Functional Requirements\|7.*Requirements"
-    "8.*Non-Functional\|8.*NFRs"
+    "7.*Functional Requirements|7.*Requirements"
+    "8.*Non-Functional|8.*NFRs"
     "9.*Out of Scope"
-    "10.*Risks\|10.*Mitigation"
-    "11.*Roadmap\|11.*Milestones"
-    "12.*PDR Summary\|12.*Product Decision"
+    "10.*Risks|10.*Mitigation"
+    "11.*Roadmap|11.*Milestones"
+    "12.*PDR Summary|12.*Product Decision"
 )
 
 MISSING_SECTIONS=0
 for section_pattern in "${REQUIRED_SECTIONS[@]}"; do
     if ! grep -qiE "^## [0-9]*\.?.*($section_pattern)" "$PRD_FILE"; then
         warn "Missing or misnumbered section matching: $section_pattern"
-        ((MISSING_SECTIONS++))
+        ((++MISSING_SECTIONS))
     fi
 done
 
@@ -302,7 +303,7 @@ for biz_pattern in "${BUSINESS_SECTIONS[@]}"; do
         pass "Found business section: $biz_pattern"
     else
         warn "Missing business section: $biz_pattern (recommended for stakeholder PRDs)"
-        ((MISSING_BUSINESS++))
+        ((++MISSING_BUSINESS))
     fi
 done
 

--- a/tests/unit/test_validate_prd.py
+++ b/tests/unit/test_validate_prd.py
@@ -1,0 +1,218 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+VALIDATOR = ROOT / "skills/product/product-implement/scripts/bash/validate-prd.sh"
+
+PASSING_PRD = """# Sample Product PRD
+
+## 1. Document Information
+
+**Product**: Sample Product
+**Version**: 1.0.0
+
+## 1.5 Executive Summary
+
+Executive summary of the sample product.
+
+## 2. Overview
+
+Overview of the sample product.
+
+```mermaid
+flowchart LR
+    A[Login] --> B[Dashboard]
+```
+
+## 3. Problem
+
+The problem being solved.
+
+## 3.5 Market Opportunity
+
+The market opportunity.
+
+## 4. Goals
+
+Goals of the product.
+
+## 5. Metrics
+
+Success metrics.
+
+## 6. Personas
+
+Primary personas.
+
+## 7. Functional Requirements
+
+### Feature Requirements
+
+- **REQ-001:** The system must authenticate users.
+  **Traced to:** PDR-001 (Authentication)
+
+- **REQ-002:** The system must allow profile editing.
+  **Traced to:** PDR-002 (Profile)
+
+```mermaid
+flowchart LR
+    R1[REQ-001] --> R2[REQ-002]
+```
+
+## 8. Non-Functional Requirements
+
+Performance and security requirements.
+
+## 9. Out of Scope
+
+Out of scope items.
+
+## 10. Risks
+
+Risks and mitigations.
+
+## 10.5 Investment
+
+Investment required.
+
+## 11. Roadmap
+
+Roadmap and milestones.
+
+## 11.5 Go-to-Market
+
+Go-to-market plan.
+
+## 12. PDR Summary
+
+Summary of product decisions.
+
+## Constitution Alignment
+
+This product aligns with the team constitution.
+"""
+
+WARNING_PRD = """# Sample Product PRD
+
+## 1. Document Information
+
+**Product**: Sample Product
+**Version**: 1.0.0
+
+## 2. Overview
+
+Overview of the sample product.
+
+```mermaid
+flowchart LR
+    A[Login] --> B[Dashboard]
+```
+
+## 3. Problem
+
+The problem being solved.
+
+## 4. Goals
+
+Goals of the product.
+
+## 5. Metrics
+
+Success metrics.
+
+## 6. Personas
+
+Primary personas.
+
+## 7. Functional Requirements
+
+### Feature Requirements
+
+- **REQ-001:** The system must authenticate users.
+  **Traced to:** PDR-001 (Authentication)
+
+- **REQ-002:** The system must allow profile editing.
+  **Traced to:** PDR-002 (Profile)
+
+## 8. Non-Functional Requirements
+
+Performance and security requirements.
+
+## 9. Out of Scope
+
+Out of scope items.
+
+## 10. Risks
+
+Risks and mitigations.
+
+## 11. Roadmap
+
+Roadmap and milestones.
+
+## 12. PDR Summary
+
+Summary of product decisions.
+"""
+
+
+def _run_validator(prd_dir, *args):
+    return subprocess.run(
+        ["bash", str(VALIDATOR), "PRD.md", *args],
+        cwd=prd_dir,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def prd_project(tmp_path):
+    project = tmp_path / "prd"
+    project.mkdir()
+    return project
+
+
+@pytest.mark.requires_bash
+def test_warn_mode_reaches_summary_instead_of_aborting(prd_project):
+    """Regression: set -e + ((WARNINGS++)) used to abort on the first warning.
+
+    A PRD that only produces warnings must complete all checks and print the
+    summary, exiting with 2 (warn mode) rather than dying at exit 1.
+    """
+    (prd_project / "PRD.md").write_text(WARNING_PRD)
+    result = _run_validator(prd_project)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Validation Summary" in result.stdout
+
+
+@pytest.mark.requires_bash
+def test_strict_mode_exits_1_on_warnings(prd_project):
+    (prd_project / "PRD.md").write_text(WARNING_PRD)
+    result = _run_validator(prd_project, "--strict")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "warning(s) found" in result.stdout
+
+
+@pytest.mark.requires_bash
+def test_canonical_req_format_is_counted(prd_project):
+    """Regression: REQ regex missed the '- **REQ-NNN:**' format the skill's own
+    requirements template emits, so REQ_COUNT was always 0."""
+    (prd_project / "PRD.md").write_text(WARNING_PRD)
+    result = _run_validator(prd_project)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Found 2 requirements" in result.stdout
+
+
+@pytest.mark.requires_bash
+def test_passing_prd_exits_0(prd_project):
+    (prd_project / "PRD.md").write_text(PASSING_PRD)
+    (prd_project / ".adlc" / "memory").mkdir(parents=True)
+    (prd_project / ".adlc" / "memory" / "constitution.md").write_text(
+        "# Team Constitution\n\n1. Human Oversight Is Mandatory\n"
+    )
+    result = _run_validator(prd_project)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "All checks passed" in result.stdout
+    assert "All requirements trace to PDRs" in result.stdout


### PR DESCRIPTION
## What

Adds an **Auto-Tag Release** workflow (`.github/workflows/auto-tag.yml`) that removes the manual tagging step after a PR merges to `main`.

## How it works

- Runs on every `push` to `main` (never on `pull_request`).
- Parses `## [X.Y.Z]` headers from `CHANGELOG.md`, compares against existing `adlc-team-skills-v*` tags.
- Creates annotated tags for every **new** untagged version **newer than the latest existing tag**, pointing at the merge commit.
- Each pushed tag triggers the existing **Release** workflow, which validates the CHANGELOG entry and creates the GitHub release — no manual tag push needed.
- Multi-version merge commits get one tag per new CHANGELOG version.

## Security

- This is the only workflow carrying `contents: write`, and it only runs on `push: main` (never on PRs), so the elevated token is never exposed to untrusted PR code. `test.yml` stays `contents: read`.
- Runs only on the canonical repo (`if: github.repository == 'tikalk/adlc-team-skills'`) to avoid forks triggering it.

## Deliberate non-behavior

- **Historical gaps are skipped.** Versions older than the latest existing tag (e.g. `0.1.0`, `0.2.0`) are never auto-tagged — tagging them at the merge commit would point at the wrong commit. They must be tagged manually at their original commit (documented in RELEASE.md).

## Files changed

- `.github/workflows/auto-tag.yml` — new workflow (validated locally: YAML parses, bash `-n` passes, logic simulated for no-op / new-version / historical-gap scenarios)
- `RELEASE.md` — release checklist now skips manual tagging; added "Automated tagging" + "Manual release" sections; clarified old-gap recovery
- `CHANGELOG.md` — `0.25.0` entry

---

## Also includes: validator fix

**fix(product-implement): repair validate-prd.sh counter abort and REQ regex** (`e7e520a`)

- **`set -e` abort** — post-increment `((VAR++))` from 0 evaluates falsy and killed the script on the first warning/error; switched to `((++VAR))` at all 5 counters.
- **REQ regex** — missed the canonical `- **REQ-NNN:**` format emitted by the skill's own requirements template, so `REQ_COUNT` was always 0; widened to optional bullet + optional colon inside bold (count + line extraction).
- **REQUIRED_SECTIONS alternation** — used BRE `\|` with `grep -E` where it is literal, so every alternation section was reported missing; now uses `|`.
- Bumped script version to `v1.5.7`.
- Added `tests/unit/test_validate_prd.py` regression suite (4 cases); all 85 unit tests pass, and the validator now reports 48 requirements on the real `agentic-sdlc/PRD.md` (was 0).