### PR TITLE
fix(ci): Node 24 runtime + auto-tag identity + diagram classDef readability

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'tikalk/adlc-team-skills'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -73,6 +73,14 @@ jobs:
           done
 
           echo "untagged=${untagged[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.versions.outputs.untagged != ''
+        run: |
+          # Annotated tags require a committer identity; runners have none by
+          # default (otherwise `git tag -a` fails with "empty ident name").
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Create and push tags
         if: steps.versions.outputs.untagged != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
           [[ -s notes.md ]] || { echo "WARNING: empty notes extracted" >&2; }
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.v.outputs.tag }}
           name: adlc-team-skills v${{ steps.v.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     name: Run Pytest (Scripts & E2E)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
       EVAL_MODEL: ${{ secrets.EVAL_MODEL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Pinned exact version + --ignore-scripts: blocks pre/postinstall
       # scripts from any of promptfoo's transitive dependencies from
       # executing during install (the vector used in the 2026-08-04 incident).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-08-09
+
+### Fixed
+
+- **Node.js 20 runtime deprecation in GitHub Actions** (`.github/workflows/*.yml`): upgraded `actions/checkout@v4` → `@v6`, `actions/setup-python@v5` → `@v6`, and `softprops/action-gh-release@v2` → `@v3` so all workflows run natively on the Node 24 runtime instead of being forced onto it (removes the "Node.js 20 is deprecated" warning; GitHub deprecated Node 20 on 2025-09-19).
+
+- **Auto-Tag Release workflow fails on `git tag -a` — "empty ident name not allowed"** (`.github/workflows/auto-tag.yml`): the workflow created annotated tags (`git tag -a`) but GitHub-hosted runners have no git identity configured by default, so the tag push step died with `fatal: empty ident name` and no release was created. Fixed by configuring `user.name`/`user.email` (github-actions[bot] identity) before creating tags.
+
 ## [0.25.0] - 2026-08-09
 
 ### Added

--- a/skills/architect/architect-analyze/templates/AD-template.md
+++ b/skills/architect/architect-analyze/templates/AD-template.md
@@ -92,7 +92,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-analyze/templates/views/context.md
+++ b/skills/architect/architect-analyze/templates/views/context.md
@@ -58,7 +58,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-clarify/templates/AD-template.md
+++ b/skills/architect/architect-clarify/templates/AD-template.md
@@ -92,7 +92,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-clarify/templates/views/context.md
+++ b/skills/architect/architect-clarify/templates/views/context.md
@@ -58,7 +58,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-implement/templates/AD-template.md
+++ b/skills/architect/architect-implement/templates/AD-template.md
@@ -92,7 +92,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-implement/templates/views/context.md
+++ b/skills/architect/architect-implement/templates/views/context.md
@@ -58,7 +58,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-init/templates/AD-template.md
+++ b/skills/architect/architect-init/templates/AD-template.md
@@ -92,7 +92,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-init/templates/views/context.md
+++ b/skills/architect/architect-init/templates/views/context.md
@@ -58,7 +58,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-specify/templates/AD-template.md
+++ b/skills/architect/architect-specify/templates/AD-template.md
@@ -92,7 +92,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/architect/architect-specify/templates/views/context.md
+++ b/skills/architect/architect-specify/templates/views/context.md
@@ -58,7 +58,7 @@ graph TD
 
     classDef systemNode fill:#f47721,stroke:#333,stroke-width:3px,color:#fff
     classDef stakeholderNode fill:#4a9eff,stroke:#333,stroke-width:1px,color:#fff
-    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px
+    classDef externalNode fill:#e0e0e0,stroke:#333,stroke-width:1px,color:#1a1a1a
 
     class System systemNode
     class Users,Admins stakeholderNode

--- a/skills/product/product-implement/templates/sections/overview.md
+++ b/skills/product/product-implement/templates/sections/overview.md
@@ -126,11 +126,11 @@ flowchart TB
     Web --> CDN
     Mobile --> CDN
     
-    classDef frontend fill:#e1f5fe,stroke:#01579b,stroke-width:2px
-    classDef gateway fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef backend fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
-    classDef data fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
-    classDef external fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    classDef frontend fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#1a1a1a
+    classDef gateway fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#1a1a1a
+    classDef backend fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#1a1a1a
+    classDef data fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#1a1a1a
+    classDef external fill:#fce4ec,stroke:#c2185b,stroke-width:2px,color:#1a1a1a
     
     class Web,Mobile,Admin frontend
     class Gateway gateway

--- a/skills/product/product-templates/prd-template.md
+++ b/skills/product/product-templates/prd-template.md
@@ -195,11 +195,11 @@ flowchart TB
     Web --> CDN
     Mobile --> CDN
     
-    classDef frontend fill:#e1f5fe,stroke:#01579b,stroke-width:2px
-    classDef gateway fill:#fff3e0,stroke:#e65100,stroke-width:2px
-    classDef backend fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
-    classDef data fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
-    classDef external fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    classDef frontend fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#1a1a1a
+    classDef gateway fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#1a1a1a
+    classDef backend fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#1a1a1a
+    classDef data fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#1a1a1a
+    classDef external fill:#fce4ec,stroke:#c2185b,stroke-width:2px,color:#1a1a1a
     
     class Web,Mobile,Admin frontend
     class Gateway gateway


### PR DESCRIPTION
## Changes

### 1. CI Node 24 runtime + auto-tag identity (`fa41c01`)
Upgrades GitHub Actions to Node 24 runtime and fixes auto-tag git identity configuration.

### 2. Diagram classDef readability fix (`761c586`)
Architect and product skill templates had mermaid `classDef` entries with light-fill backgrounds but **no `color` property**, causing text to inherit a light theme color on dark renderers (GitLab/GitHub dark mode) — white text on light-gray/pastel = unreadable.

**Fixed 20 classDefs across 12 template files:**

| Skills | classDefs fixed |
|--------|---------------|
| **Architect** (analyze, clarify, implement, init, specify) | `externalNode fill:#e0e0e0` → added `color:#1a1a1a` (10 files: `AD-template.md` + `views/context.md` × 5) |
| **Product** (product-implement, product-templates) | `frontend`, `gateway`, `backend`, `data`, `external` pastel-fill classDefs → added `color:#1a1a1a` (2 files: `overview.md` + `prd-template.md`, 5 classDefs each) |

**Root cause**: Mermaid classDef without `color` inherits from the theme — on dark themes this produces light-on-light text. Fix: explicit `color:#1a1a1a` (dark text) on all light-fill classDefs.

**Testing**: Templates are consumed by `/architect.implement` and `/product.implement` to generate AD.md and PRD.md mermaid diagrams. The generated diagrams (already committed in asdlc-workspace) were fixed separately (commit `931512a`); this PR fixes the **source templates** so future generations produce readable diagrams.