### PR TITLE
feat: add change-* skill family — ChDRs from git history + team-boot injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2026-08-17
+
+### Added
+
+- **`change-*` skill family — Change Decision Records from git history** (`skills/change/change-{init,clarify,publish}/`): a new record type (ChDR) that mines the *why* behind how code came to be, recovered from commit messages + linked issue trackers rather than from current code patterns or the current session. `change-init` scans a `git log` window, auto-detects issue links (JIRA keys, GitHub/GitLab `#NNN`, MR `!NNN`, issue URLs), clusters commits by issue key into change stories, best-effort fetches issue context (GitLab via MCP, GitHub via `gh`, else link-only), and treats revert/fix chains as first-class negative knowledge. `change-clarify` is the human gate (one-ChDR-at-a-time Accept/Reject/Defer) with a provenance check that rejects Decision claims lacking a cited commit SHA or issue URL (the context-poisoning circuit breaker). `change-publish` promotes accepted ChDRs to `.adlc/memory/chdr/` and regenerates the boot-facing `.adlc/memory/chdr.md` index. Every Decision claim carries mandatory provenance; linkage-rate metric in the summary sets expectations about corpus quality (research: rationale density varies 85–99% on disciplined projects, far lower elsewhere). ChDRs publish to project-local memory, not team-ai-directives (they describe this repo's evolution and fail the levelup team-wide signal gate). Empirical foundation: CoMRAT (MSR 2025), DRMiner (ASE 2024), LaToza et al. (ICSE 2006), Ko et al. (ICSE 2007).
+
+- **`team-boot` injects the ChDR index at session start** (`skills/team/team-boot/scripts/boot.sh`, `boot.ps1`, `SKILL.md`): alongside the existing PDR/ADR indexes, `team-boot` now reads `.adlc/memory/chdr.md` and emits a `## ChDR Index` section with `CHDR_COUNT`, so published Change Decision Records are available to every session. The counts line is extended to `_Searched N CDR, P PDR, A ADR, C ChDR entries, S skills, J matched._`. `team-discover` updated to include ChDR matches.
+
+- **Eval coverage for the change family** (`evals/promptfoo/graders/check_chdr_format.py`, `evals/promptfoo/tests/test_check_chdr_format.py`, `evals/promptfoo/goldset.md`): new goldset criterion (EVAL-006) and binary grader asserting ChDR drafts contain required sections (`Context`/`Decision`/`Consequences`/`Evidence`), at least one commit SHA, an issue link or explicit "no linked issue" marker, and provenance on Decision claims. Follows CONTRIBUTING's "new skills ship with eval coverage" requirement.
+
+- **`levelup-init` / `levelup-specify` "When NOT to use"** (`skills/levelup/levelup-{init,specify}/SKILL.md`): added a pointer to `/change-init` for mining git history / issue-linked changes, keeping discovery-source routing unambiguous.
+
 ## [0.25.1] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ in a clone as executable code, and disable editor auto-run tasks.
 - **`levelup-clarify`** — review, accept, reject, or defer pending CDRs.
 - **`levelup-publish`** — compile accepted CDRs into directives + goldensets + draft PR.
 
+### Change (ChDRs)
+
+- **`change-init`** — mine git history for Change Decision Records via issue-linked commits; recovers the *why* behind past changes (reverts, fix chains).
+- **`change-clarify`** — review, accept, reject, or defer mined ChDRs (provenance gate on Decision claims).
+- **`change-publish`** — promote accepted ChDRs to `.adlc/memory/chdr/`; `team-boot` injects the `chdr.md` index at session start.
+
 ### Product (PDRs)
 
 - **`product-init`** — brownfield PDR discovery. **`product-specify`** — greenfield creation.
@@ -206,6 +212,7 @@ skills/
 ├── architect/             # architect-* (5 skills)
 ├── product/               # product-* (6 skills) + product-templates/
 ├── levelup/               # levelup-* (4 skills) + levelup-helpers.{sh,ps1}
+├── change/                # change-* (3 skills) — ChDRs from git history
 ├── mission-brief/         # core SDD orchestrator (1 skill)
 ├── evals/                 # evals-* (6 skills) + evals-templates/
 ├── tech-radar/            # tech-radar-* (1 skill) + resources/radar.json
@@ -335,6 +342,7 @@ Greenfield: architect-specify → architect-clarify → architect-implement → 
 ```
 Brownfield: levelup-init → levelup-clarify → levelup-publish → team-repair
 Session:    levelup-specify → levelup-clarify → levelup-publish → team-repair
+History:    change-init → change-clarify → change-publish (team-boot injects chdr.md)
 Build to Delete: team-repair --build-to-delete → levelup-clarify (review deletion CDRs)
 ```
 

--- a/evals/promptfoo/goldset.md
+++ b/evals/promptfoo/goldset.md
@@ -111,3 +111,24 @@ The delegation prompt omits the skills list, does not instruct the subagent to i
 - **Scenario**: Delegation prompt with hard-coded mapping
 - **Input Context**: Skills inventory provided but prompt uses static lookup.
 - **Agent Output**: "Phase implement → skill tdd. Phase converge → skill code-review. Execute the mapped skill for this phase."
+
+## Criterion EVAL-006: Change Decision Record (ChDR) Format Integrity
+
+**Status**: published
+**Description**: Verifies that a Change Decision Record mined by `/change-init` has the four required sections (Context, Decision, Consequences, Evidence), at least one commit SHA as a provenance anchor, an issue link or an explicit "no linked issue" marker, and provenance (SHA or URL) on the Decision claims — the context-poisoning circuit breaker that prevents unprovenanced inferred rationale from entering project memory.
+
+### Pass Condition
+The ChDR draft contains `### Context`, `### Decision`, `### Consequences`, and `### Evidence` headings; at least one commit SHA (7-40 hex chars) somewhere in the record; an issue link (JIRA key, GitHub/GitLab `#NNN`, MR `!NNN`, or issue URL) OR an explicit "no linked issue" / "none detected" marker; and at least one SHA or URL inside the Decision section body (provenance on the inferred decision).
+
+### Fail Condition
+The ChDR is missing any required section, has no commit SHA, has neither an issue link nor a no-link marker, or the Decision section states inferred rationale without citing any SHA or URL (unprovenanced — poisoning risk).
+
+### Pass Example 1
+- **Scenario**: A complete ChDR mined from an issue-linked commit cluster
+- **Input Context**: Git history with commit `abc1234` referencing `PROJ-123`.
+- **Agent Output**: A ChDR with all four sections, `### Issue Links: PROJ-123`, `### Commits: abc1234`, and a Decision section citing `abc1234` inline ("capped at 3 (abc1234) because...").
+
+### Fail Example 1
+- **Scenario**: A ChDR whose Decision section infers rationale without citing evidence
+- **Input Context**: Git history with a terse commit and no linked issue.
+- **Agent Output**: A ChDR with all sections and a SHA in Evidence, but the Decision section reads "The cap was chosen for performance reasons" with no SHA or URL — unprovenanced inferred rationale.

--- a/evals/promptfoo/graders/check_chdr_format.py
+++ b/evals/promptfoo/graders/check_chdr_format.py
@@ -1,0 +1,60 @@
+import re
+
+def get_assert(output: str, context: dict = None) -> dict:
+    """Grader for EVAL-006: Change Decision Record (ChDR) format integrity.
+
+    Asserts a mined ChDR draft has:
+      - the four required sections (Context, Decision, Consequences, Evidence)
+      - at least one commit SHA (provenance anchor)
+      - an issue link OR an explicit "no linked issue" marker
+      - provenance on Decision claims: at least one SHA or URL appears in the
+        Decision section body (the context-poisoning circuit breaker — an
+        unprovenanced inferred rationale is worse than no rationale).
+    """
+    reasons = []
+
+    # Required sections (### headings — allow trailing text on the line,
+    # e.g. "### Decision (confidence: HIGH)")
+    required_sections = ["Context", "Decision", "Consequences", "Evidence"]
+    for sec in required_sections:
+        if not re.search(rf"^###\s+{sec}\b", output, re.MULTILINE):
+            reasons.append(f"missing section: {sec}")
+
+    # At least one commit SHA (7-40 hex chars) anywhere
+    has_sha = re.search(r"\b[0-9a-f]{7,40}\b", output, re.IGNORECASE)
+    if not has_sha:
+        reasons.append("no commit SHA found (provenance anchor missing)")
+
+    # Issue link OR explicit "no linked issue" marker
+    issue_link = re.search(
+        r"(\b[A-Z][A-Z0-9]+-\d+\b|https?://\S+/(?:issues|pull|merge_requests|browse)/\S+)",
+        output,
+    )
+    no_link_marker = re.search(r"no linked issue|none detected", output, re.IGNORECASE)
+    if not issue_link and not no_link_marker:
+        reasons.append("no issue link and no explicit 'no linked issue' marker")
+
+    # Provenance on Decision claims: extract the Decision section body and
+    # require at least one SHA or URL inside it.
+    decision_body = ""
+    m = re.search(r"^###\s+Decision\b[^\n]*\n(.*?)(?=^###\s|\Z)", output, re.MULTILINE | re.DOTALL)
+    if m:
+        decision_body = m.group(1)
+        decision_has_provenance = re.search(
+            r"(\b[0-9a-f]{7,40}\b|https?://\S+)", decision_body, re.IGNORECASE
+        )
+        if not decision_has_provenance:
+            reasons.append("Decision section has no SHA/URL provenance on its claims")
+
+    if reasons:
+        return {
+            "pass": False,
+            "score": 0.0,
+            "reason": "ChDR format check failed: " + "; ".join(reasons),
+        }
+
+    return {
+        "pass": True,
+        "score": 1.0,
+        "reason": "ChDR has all required sections, a commit SHA, an issue link or no-link marker, and Decision provenance.",
+    }

--- a/evals/promptfoo/tests/test_check_chdr_format.py
+++ b/evals/promptfoo/tests/test_check_chdr_format.py
@@ -1,0 +1,108 @@
+"""Unit test for check_chdr_format.py grader.
+
+Verifies the grader produces correct pass/fail results for ChDR drafts.
+Follows the evals-implement Phase 2 closed-loop self-tuning pattern.
+"""
+import sys
+from pathlib import Path
+
+# Add graders dir to path so we can import the grader directly.
+graders_dir = Path(__file__).parent.parent / "graders"
+sys.path.insert(0, str(graders_dir))
+
+from check_chdr_format import get_assert
+
+
+# ---------------------------------------------------------------------------
+# Pass cases
+# ---------------------------------------------------------------------------
+
+PASS_CHDR = """## ChDR-001: Why payments retries are capped at 3
+
+### Status: **Discovered**
+### Date: 2026-08-16
+### Source: Git history via /change-init
+### Issue Links: PROJ-123
+### Commits: abc1234
+### Descriptor: Consult before changing retry config.
+
+### Context
+Issue PROJ-123 reported retries running forever under network partitions.
+Commit abc1234 introduced the cap.
+
+### Decision (confidence: HIGH)
+The retry count is capped at 3 (abc1234) because unbounded retries caused
+cascade failures during the 2026-03 incident.
+
+### Consequences
+None observed — no later revert or fix chain touches this path.
+
+### Evidence
+- abc1234: cap payments retries at 3
+- src/payments/retry.ts: MAX_RETRIES = 3
+- https://gitlab.example.com/proj/issues/123: Payments retry loop never terminates
+"""
+
+
+def test_pass_full_chdr():
+    """A complete ChDR with all sections, SHA, issue link, and Decision provenance passes."""
+    result = get_assert(PASS_CHDR)
+    assert result["pass"] is True
+    assert result["score"] == 1.0
+
+
+def test_pass_no_linked_issue_marker():
+    """A ChDR with the explicit 'no linked issue' marker passes (issue link not required)."""
+    chdr = PASS_CHDR.replace(
+        "### Issue Links: PROJ-123", "### Issue Links: none detected"
+    ).replace("https://gitlab.example.com/proj/issues/123: Payments retry loop never terminates",
+              "no issue link — commit message only")
+    result = get_assert(chdr)
+    assert result["pass"] is True
+    assert result["score"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Fail cases
+# ---------------------------------------------------------------------------
+
+def test_fail_missing_section():
+    """Missing the Consequences section fails."""
+    chdr = PASS_CHDR.replace("### Consequences\nNone observed — no later revert or fix chain touches this path.\n", "")
+    result = get_assert(chdr)
+    assert result["pass"] is False
+    assert result["score"] == 0.0
+    assert "Consequences" in result["reason"]
+
+
+def test_fail_no_sha():
+    """No commit SHA anywhere fails (provenance anchor missing)."""
+    chdr = PASS_CHDR.replace("abc1234", "fix-branch").replace("[0-9a-f]", "x")
+    # Remove the SHA entirely; keep an issue link so only the SHA check fails
+    result = get_assert(chdr)
+    assert result["pass"] is False
+    assert "SHA" in result["reason"]
+
+
+def test_fail_no_issue_link_and_no_marker():
+    """Neither an issue link nor a 'no linked issue' marker fails."""
+    # Remove every issue-link reference (Issue Links line, Context mention, Evidence URL)
+    chdr = PASS_CHDR.replace("### Issue Links: PROJ-123", "### Issue Links: ")
+    chdr = chdr.replace("Issue PROJ-123 reported retries running forever under network partitions.",
+                        "Retries ran forever under network partitions.")
+    chdr = chdr.replace("https://gitlab.example.com/proj/issues/123: Payments retry loop never terminates",
+                        "issue not tracked")
+    result = get_assert(chdr)
+    assert result["pass"] is False
+    assert "issue link" in result["reason"].lower()
+
+
+def test_fail_decision_without_provenance():
+    """Decision section with no SHA/URL provenance fails (poisoning risk)."""
+    chdr = PASS_CHDR.replace(
+        "### Decision (confidence: HIGH)\nThe retry count is capped at 3 (abc1234) because unbounded retries caused\ncascade failures during the 2026-03 incident.\n",
+        "### Decision (confidence: HIGH)\nThe retry count is capped at 3 because unbounded retries caused cascade failures.\n",
+    )
+    result = get_assert(chdr)
+    assert result["pass"] is False
+    assert "provenance" in result["reason"].lower()

--- a/skills/change/change-clarify/SKILL.md
+++ b/skills/change/change-clarify/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: change-clarify
+description: Review, accept, reject, or defer Change Decision Records (ChDRs) discovered by change-init. Interactive one-ChDR-at-a-time workflow that validates inferred decisions against their git/issue evidence before promotion to project memory.
+disable-model-invocation: true
+---
+
+# change-clarify
+
+## What this skill does
+
+Review pending ChDRs (status **Discovered** or **Proposed**) and decide their fate: **Accepted**, **Rejected**, or **Deferred**.
+
+This is the quality gate for Change Decision Records — the human checkpoint before inferred-from-history decisions are promoted to project memory and injected into future sessions by `team-boot`:
+
+- Validate that inferred decisions are supported by cited commit SHAs / issue URLs (provenance — the context-poisoning circuit breaker)
+- Check inferred-rationale confidence and flag low-confidence or unsupported claims
+- Confirm issue-link validity and that fetched issue summaries are accurate (not pasted verbatim)
+- Ensure Consequences (reverts/fix chains) are recorded where observed
+- Update ChDR statuses in `{REPO_ROOT}/.adlc/drafts/chdr/ChDR-{NNN}.md`
+- Regenerate `{REPO_ROOT}/.adlc/drafts/chdr/chdr.md` index
+
+**This is an interactive command.** Present exactly one ChDR per interaction and wait for user input.
+
+## When to use
+
+- **After `/change-init`**: validate history-mined ChDRs before promotion
+- **Periodic review**: clean up stale pending ChDRs
+
+### When NOT to use
+
+- **No pending ChDRs**: if no ChDRs have status Discovered/Proposed, there is nothing to clarify
+- **Reviewing CDRs**: use `/levelup-clarify` (CDRs and ChDRs are distinct record types with separate gates)
+- **Direct editing**: do not use this skill to bypass the review workflow
+
+## Process
+
+### User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+**Examples of User Input**:
+
+- `"ChDR-001 ChDR-003"` — focus on specific ChDRs
+- `"all"` — clarify all pending ChDRs
+- Empty input: clarify all ChDRs with status "Discovered" or "Proposed"
+
+### Flags
+
+- `--all`: clarify all pending ChDRs (same as empty input)
+- `--limit N`: limit to N clarifications per session (default: 5)
+
+### Role & Context
+
+You are acting as a **Change Validator** reviewing inferred-from-history decisions. Unlike CDR clarification (which validates team-wide patterns), your focus is **evidence fidelity**:
+
+- Was the Decision actually inferable from the cited commits, or did the agent invent it?
+- Is the confidence level honest (a HIGH-confidence claim with a terse commit + no issue link is suspicious)?
+- Are issue summaries accurate and not leaking sensitive detail verbatim?
+- Are reverts/fix chains recorded where they exist (the highest-value content)?
+
+#### ChDR Quality Checklist
+
+Each ChDR should have:
+
+- [ ] `### Context` explaining why the change happened (issue summary or commit messages)
+- [ ] `### Decision` with inferred decision + confidence level
+- [ ] **Every Decision claim cites a SHA or issue URL** (provenance — non-negotiable)
+- [ ] `### Consequences` (reverts/fix chains, or explicit "None observed")
+- [ ] `### Evidence` with concrete SHAs, files, and issue links
+- [ ] Issue summaries are paraphrased, not raw paste (security)
+- [ ] Status is accurate
+
+### Outline
+
+1. **Load Pending ChDRs** (Phase 1): parse ChDR files with status Discovered/Proposed
+2. **Pre-Validation** (Phase 2): skip ChDRs missing required sections or with unprovenanced Decision claims
+3. **Gap Identification** (Phase 3): list clarification needs
+4. **Sequential Clarification** (Phase 4): one ChDR per interaction
+5. **Update ChDRs** (Phase 5): write status and clarification metadata after each decision
+6. **Regenerate Index** (Phase 6): update `chdr.md`
+7. **Summary** (Phase 7): present results
+
+### Execution Steps
+
+#### Phase 1: Load Pending ChDRs
+
+Run setup script:
+
+```bash
+scripts/bash/setup-change-clarify.sh
+```
+
+Read all `{REPO_ROOT}/.adlc/drafts/chdr/ChDR-*.md` files and filter:
+
+- **Include**: `### Status: **Discovered**` or `### Status: **Proposed**`
+- **Skip**: `### Status: **Accepted**`, `**Rejected**`, `**Published**`, `**Deprecated**`
+
+**If the setup script is unavailable or fails**, resolve manually:
+
+1. `REPO_ROOT` — walk up from cwd to find `.adlc/`, or `git rev-parse --show-toplevel`.
+2. `CHDR_DRAFTS_DIR` — `REPO_ROOT/.adlc/drafts/chdr`
+3. `PENDING_COUNT` — count files with Discovered/Proposed status.
+
+If no pending ChDRs:
+
+```text
+No pending ChDRs found.
+Run /change-init to mine git history first.
+```
+
+#### Phase 2: Pre-Validation
+
+For each pending ChDR, check required sections:
+
+- `### Context`
+- `### Decision` (with at least one confidence marker)
+- `### Consequences`
+- `### Evidence`
+- **Provenance**: every non-trivial sentence in `### Decision` references a SHA (`\b[0-9a-f]{7,40}\b`) or URL (`https?://`)
+
+Skip invalid ChDRs and report:
+
+```markdown
+## Skipped ChDRs
+
+| ChDR | Issue | Action |
+|---|---|---|
+| ChDR-XXX | Decision claims lack SHA/URL provenance | Re-run /change-init or add evidence manually |
+```
+
+#### Phase 3: Gap Identification
+
+Generate a gap report:
+
+```markdown
+## ChDR Clarification Report
+
+| ChDR | Title | Gap Type | Severity |
+|---|---|---|---|
+| ChDR-001 | [Title] | Low-confidence decision | MEDIUM |
+| ChDR-002 | [Title] | Issue summary too verbose | LOW |
+```
+
+Gap types:
+
+- **Low-confidence decision**: Decision marked LOW confidence — consider rejecting or deferring
+- **Unprovenanced claim**: a Decision sentence without SHA/URL (should have been caught in Phase 2)
+- **Issue summary too verbose**: pasted verbatim instead of paraphrased (security)
+- **Missing consequences**: Consequences section empty but reverts observed in window
+- **Stale**: cluster's commits later reverted (the decision was reversed — mark for rejection or status reversal)
+
+#### Phase 4: Sequential Clarification
+
+**CRITICAL**: Present exactly ONE ChDR per interaction. Do NOT:
+
+- Present multiple ChDRs together
+- Auto-select actions
+- Proceed without explicit user input
+- Ask more than one question at a time
+
+**Session limit**: Default 5 ChDRs per session. User can say "done" to exit early.
+
+For each ChDR:
+
+```markdown
+## ChDR-{ID}: {Title}
+
+**Status**: {status}
+**Issue Links**: {links or "none"}
+**Commits**: {sha list}
+
+### Current Content
+
+**Context**:
+{context}
+
+**Decision** (confidence: {level}):
+{decision}
+
+**Consequences**:
+{consequences}
+
+**Evidence**:
+{evidence}
+
+### Choose Action
+
+| Option | Action |
+|---|---|
+| A | **Accept** — Approve for promotion to memory |
+| B | **Reject** — Decline with reason |
+| C | **Defer** — Skip for now, keep pending |
+| D | **Accept all remaining** — Accept this ChDR and all pending ChDRs without further review |
+
+Reply with your choice (A/B/C/D).
+```
+
+Wait for user input before proceeding.
+
+#### Action A: Accept
+
+Update status to `### Status: **Accepted**`. Add clarification metadata:
+
+```markdown
+### Clarification
+
+- **Date**: [YYYY-MM-DD]
+- **Action**: Accepted
+- **Rationale**: [summary of review]
+```
+
+#### Action D: Accept All Remaining
+
+Accept the current ChDR (Action A), then iterate remaining pending ChDRs marking each `### Status: **Accepted**` with bulk metadata. Skip per-ChDR presentation. Proceed to Phase 6.
+
+#### Action B: Reject
+
+Ask for reason:
+
+```markdown
+### Decision: Reject
+
+| Option | Reason |
+|---|---|
+| A | Decision was reversed (later reverted) |
+| B | Inferred rationale unsupported by evidence |
+| C | Project-specific / not worth recording |
+| D | Duplicate of an existing ChDR or ADR |
+
+Reply with your choice.
+```
+
+Update status to `### Status: **Rejected**` with reason.
+
+#### Action C: Defer
+
+Keep status as-is. Add note:
+
+```markdown
+### Clarification
+
+- **Date**: [YYYY-MM-DD]
+- **Action**: Deferred
+- **Reason**: [need more context / waiting on team / low priority]
+```
+
+#### Phase 5: Update ChDR Files
+
+After EACH ChDR interaction, immediately update the file. Do not batch at the end.
+
+#### Phase 6: Regenerate Index
+
+Regenerate `{REPO_ROOT}/.adlc/drafts/chdr/chdr.md` by listing all `ChDR-*.md` files and building the markdown table from single-line fields (`### Status:`, `### Date:`, `### Issue Links:`, `### Commits:`, `### Descriptor:`).
+
+#### Phase 7: Summary
+
+```markdown
+## Change-Clarify Summary
+
+**ChDRs Reviewed**: N
+**Accepted**: N
+**Rejected**: N
+**Deferred**: N
+
+### Accepted (Ready for Promotion)
+
+| ChDR | Title |
+|---|---|
+| ChDR-001 | [Title] |
+
+### Rejected
+
+| ChDR | Reason |
+|---|---|
+| ChDR-003 | Decision was reversed (later reverted) |
+
+### Deferred
+
+| ChDR | Title |
+|---|---|
+| ChDR-004 | [Title] |
+
+### Next Steps
+
+1. **Accepted**: Run `/change-publish` to promote to `.adlc/memory/chdr/`
+2. **Deferred**: will appear in next clarify session
+3. **Remaining**: run `/change-clarify` again to continue
+```
+
+### Key Rules
+
+#### One-at-a-Time
+
+- Present exactly ONE ChDR per response
+- Ask exactly ONE question per response
+- Wait for user input before proceeding
+
+#### Immediate Writes
+
+- Update ChDR file after each decision
+- Regenerate index after session ends
+
+#### No Auto-Approval
+
+- Never accept or reject without explicit user choice
+- Do not assume user preference
+
+#### Provenance Is the Gate
+
+- A Decision claim without SHA/URL provenance is a poisoning risk — reject or require evidence before accepting
+- LOW-confidence decisions are acceptable to accept if evidence is solid; HIGH-confidence with no evidence is not
+
+### Workflow Guidance & Transitions
+
+#### After `/change-clarify`
+
+If any ChDRs were **Accepted**, handoff to `/change-publish`:
+
+```json
+{
+  "command": "clarify",
+  "accepted": ["ChDR-001", "ChDR-002"],
+  "rejected": ["ChDR-003"],
+  "deferred": ["ChDR-004"]
+}
+```
+
+#### Complete Clarify Flow
+
+```text
+[Pending ChDRs exist]
+    ↓
+/change-clarify
+    ↓
+[One ChDR at a time] → Accept / Reject / Defer
+    ↓
+[Run /change-publish] → Promote accepted ChDRs to .adlc/memory/chdr/
+```
+
+## Next Steps
+
+After accepting ChDRs, run `/change-publish` to promote them to project memory and regenerate the boot-facing `chdr.md` index.
+
+## Verification
+
+- All reviewed ChDR files updated with new status and clarification metadata.
+- `chdr.md` drafts index regenerated.
+- Accepted ChDRs are ready for `/change-publish`.
+- No ChDRs were auto-accepted or auto-rejected without user input.
+- Accepted ChDRs all have provenance on Decision claims.
+
+## Context
+
+$ARGUMENTS

--- a/skills/change/change-clarify/scripts/bash/setup-change-clarify.sh
+++ b/skills/change/change-clarify/scripts/bash/setup-change-clarify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# setup-change-clarify.sh — Setup for change-clarify (self-contained)
+set -euo pipefail
+
+resolve_project_root() {
+  local dir
+  dir="$(pwd)"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -d "${dir}/.adlc" ]]; then
+      echo "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+PROJECT_ROOT=$(resolve_project_root)
+CHDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/chdr"
+MEMORY_DIR="${PROJECT_ROOT}/.adlc/memory/chdr"
+
+mkdir -p "$CHDR_DRAFTS_DIR" 2>/dev/null || true
+
+ACCEPTED_CHDRS=$( { grep -l '^### Status: \*\*Accepted\*\*' "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+PENDING_CHDRS=$( { grep -lE '^### Status: \*\*(Discovered|Proposed)\*\*' "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+EXISTING_CHDRS=$( { ls -1 "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+
+python3 - "$PROJECT_ROOT" "$CHDR_DRAFTS_DIR" "$MEMORY_DIR" "$ACCEPTED_CHDRS" "$PENDING_CHDRS" "$EXISTING_CHDRS" << 'PY'
+import json, sys
+print(json.dumps({
+  "REPO_ROOT": sys.argv[1],
+  "CHDR_DRAFTS_DIR": sys.argv[2],
+  "MEMORY_DIR": sys.argv[3],
+  "ACCEPTED_CHDRS": int(sys.argv[4]),
+  "PENDING_CHDRS": int(sys.argv[5]),
+  "EXISTING_CHDRS": int(sys.argv[6])
+}))
+PY

--- a/skills/change/change-clarify/scripts/powershell/setup-change-clarify.ps1
+++ b/skills/change/change-clarify/scripts/powershell/setup-change-clarify.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+# setup-change-clarify.ps1 — Setup for change-clarify (self-contained)
+$ErrorActionPreference = "Stop"
+
+function Resolve-ProjectRoot {
+    $dir = $PSScriptRoot
+    while ($dir -ne "") {
+        if (Test-Path (Join-Path $dir ".adlc")) { return $dir }
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if ($gitRoot) { return $gitRoot }
+    return (Get-Location).Path
+}
+
+$ProjectRoot = Resolve-ProjectRoot
+$ChdrDraftsDir = Join-Path $projectRoot ".adlc/drafts/chdr"
+$MemoryDir = Join-Path $projectRoot ".adlc/memory/chdr"
+
+if (-not (Test-Path $ChdrDraftsDir)) { New-Item -ItemType Directory -Path $ChdrDraftsDir -Force | Out-Null }
+
+$AcceptedChdrs = 0
+$PendingChdrs = 0
+$ExistingChdrs = @(Get-ChildItem -Path $ChdrDraftsDir -Filter "ChDR-*.md" -ErrorAction SilentlyContinue).Count
+if ($ExistingChdrs -gt 0) {
+    Get-ChildItem -Path $ChdrDraftsDir -Filter "ChDR-*.md" -ErrorAction SilentlyContinue | ForEach-Object {
+        $content = Get-Content $_.FullName -Raw
+        if ($content -match '### Status: \*\*Accepted\*\*') { $AcceptedChdrs++ }
+        elseif ($content -match '### Status: \*\*(Discovered|Proposed)\*\*') { $PendingChdrs++ }
+    }
+}
+
+$output = @{
+    REPO_ROOT = $projectRoot
+    CHDR_DRAFTS_DIR = $ChdrDraftsDir
+    MEMORY_DIR = $MemoryDir
+    ACCEPTED_CHDRS = $AcceptedChdrs
+    PENDING_CHDRS = $PendingChdrs
+    EXISTING_CHDRS = $ExistingChdrs
+}
+$output | ConvertTo-Json -Compress

--- a/skills/change/change-init/SKILL.md
+++ b/skills/change/change-init/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: change-init
+description: Mine git history for Change Decision Records (ChDRs) by detecting commit messages that link to issue trackers, clustering the commits into change stories, and inferring the decisions behind them. Use when bootstrapping project memory from an existing repo's history (brownfield), before refactoring unfamiliar code, or to recover rationale that was never documented.
+disable-model-invocation: true
+---
+
+# change-init
+
+## What this skill does
+
+Mine **git history** for **Change Decision Records (ChDRs)** — the *why* behind how the code came to be — and write them as draft records for human review.
+
+A ChDR captures a decision that was *made in the past* and survives only in commits + linked issue trackers:
+
+- Scan a window of `git log` for commit messages that reference an issue tracker (JIRA keys, GitHub/GitLab `#NNN`, MR `!NNN`, or issue URLs)
+- Cluster commits sharing one issue key into a single **change story**
+- Best-effort fetch the issue title/body (GitLab via MCP, GitHub via `gh`, else link-only) for requirement-level context
+- Infer the **Decision** from the diff summary; record **Consequences** (reverts, follow-up fix chains — the negative knowledge almost never documented elsewhere)
+- Write `ChDR-{NNN}.md` to `{REPO_ROOT}/.adlc/drafts/chdr/` with status **Discovered**
+- Regenerate `{REPO_ROOT}/.adlc/drafts/chdr/chdr.md` index
+
+**Key differences from the levelup family**:
+
+| Skill | Source | Record | Question answered |
+|---|---|---|---|
+| `/levelup-init` | current code (what IS) | CDR (Context Directive) | what patterns are reusable |
+| `/levelup-specify` | current session | CDR | what was learned this session |
+| `/change-init` (this skill) | **git history** (why it BECAME) | **ChDR** (Change Decision) | **why this code exists / what was tried and reverted** |
+
+ChDRs are **project-local memory** (this repo's evolution), not team-wide context — they fail the levelup "team-wide applicability" signal gate. They publish to `{REPO_ROOT}/.adlc/memory/chdr/` (see `/change-publish`), and their index is injected at session start by `team-boot`.
+
+## When to use
+
+- **Brownfield onboarding**: give an agent project memory without anyone writing docs
+- **Before refactoring unfamiliar code**: surface Chesterton's fences — constraints that exist only in old commits + tickets
+- **Recovering lost rationale**: when ADRs were never written but commits + issues exist
+- **Post-incident learning**: revert/fix chains are first-class output
+
+### When NOT to use
+
+- **Greenfield / no history**: nothing to mine
+- **Documenting current patterns**: use `/levelup-init` (what IS)
+- **Capturing this session's learnings**: use `/levelup-specify`
+- **Pending ChDRs already exist**: run `/change-clarify` to review them first
+
+## Process
+
+### User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+**Examples of User Input**:
+
+- `"--since 6months"` — limit the scan window
+- `"--tracker gitlab"` — force tracker type (auto by default)
+- `"--no-fetch"` — record issue links only, never fetch issue bodies
+- `"--include-unlinked"` — also surface signal-rich unlinked commits (reverts, large cross-cutting diffs)
+- `"src/payments"` — restrict to a path
+- Empty input: scan last 500 commits across the whole repo, auto-detect tracker
+
+### Flags
+
+- `--since DATE` / `--until DATE` / `--max-count N` (default 500): `git log` windowing
+- `--path PATH`: restrict to a pathspec
+- `--tracker gitlab|github|jira|auto` (default `auto`): issue-tracker integration
+- `--no-fetch`: detect+record issue links only, never fetch bodies
+- `--include-unlinked`: also cluster signal-rich unlinked commits (reverts, diffs touching ≥3 subsystems)
+- `--limit N` (default 20): cap number of ChDRs generated
+- `--resume`: resume from previous interrupted state
+
+### Role & Context
+
+You are a **Context Archaeologist** recovering *why* the code is the way it is. Your job is **inference from evidence**, not invention:
+
+- Every Decision claim MUST cite the commit SHA(s) and/or issue URL it was inferred from (provenance is non-negotiable — an unprovenanced inferred rationale is context poisoning, worse than no rationale)
+- Mark confidence (HIGH/MEDIUM/LOW) on each Decision
+- Record what you do NOT know explicitly ("Reason for choice unknown — commit message terse, no linked issue")
+- Reverts and follow-up fix chains are the highest-value content: they are negative knowledge ("we tried X, it broke Y") documented almost nowhere else
+
+### Outline
+
+1. **Validate Environment** (Phase 1): git repo, resolve paths, next ChDR number
+2. **Scan Window** (Phase 2): `git log` with windowing
+3. **Detect Issue Links** (Phase 3): regex over commit messages
+4. **Cluster into Change Stories** (Phase 4): group commits by issue key
+5. **Best-Effort Issue Fetch** (Phase 5): tracker content (degrade gracefully)
+6. **Detect Revert/Fix Chains** (Phase 6): first-class negative knowledge
+7. **Score & Prioritize** (Phase 7): subsystems touched, diff size, chains
+8. **Generate ChDRs** (Phase 8): write drafts + index
+9. **Output** (Phase 9): summary with linkage-rate metric
+
+### Execution Steps
+
+#### Phase 1: Validate Environment
+
+Run the setup script from the skill's base directory:
+
+```bash
+scripts/bash/setup-change-init.sh
+```
+
+Parse the JSON output for `REPO_ROOT`, `CHDR_DRAFTS_DIR`, `NEXT_CHDR`, `GIT_AVAILABLE`, `DEFAULT_BRANCH`, `TD_CONFIGURED`, `EXISTING_CHDRS`.
+
+**If the setup script is unavailable or fails**, resolve manually:
+
+1. `REPO_ROOT` — walk up from cwd to find `.adlc/`, or `git rev-parse --show-toplevel`, or `pwd`.
+2. `CHDR_DRAFTS_DIR` — `REPO_ROOT/.adlc/drafts/chdr`
+3. `NEXT_CHDR` — list `CHDR_DRAFTS_DIR/ChDR-*.md`, find highest number, increment, zero-pad to 3 digits.
+4. `GIT_AVAILABLE` — `git rev-parse --is-inside-work-tree` (exit 0 = true).
+5. `TD_CONFIGURED` — true if `TEAM_AI_DIRECTIVES` resolves (used only to skip duplicate decisions already captured as CDRs).
+
+**If `GIT_AVAILABLE` is false**:
+
+```text
+Not a git repository — change-init has nothing to mine.
+Run /levelup-init to scan current code instead.
+```
+
+Exit cleanly (do not create empty drafts).
+
+#### Phase 2: Scan Window
+
+```bash
+git log --pretty=format:'%H%x09%an%x09%ad%x09%s%n%b' --date=short \
+  ${SINCE:+--since="$SINCE"} ${UNTIL:+--until="$UNTIL"} --max-count="${MAX_COUNT:-500}" \
+  ${PATHSPEC:+-- "$PATHSPEC"} 2>/dev/null
+```
+
+Capture per commit: SHA, author, date, subject, body, files touched (`git show --stat --name-only`), and subsystems (top-level dirs of touched files).
+
+#### Phase 3: Detect Issue Links
+
+Apply a combined regex to each commit message (subject + body):
+
+| Pattern | Tracker | Example |
+|---|---|---|
+| `\b[A-Z][A-Z0-9]+-\d+\b` | JIRA | `PROJ-123` |
+| `(?<!\w)#\d+\b` | GitHub/GitLab issue | `#123` |
+| `\b!\d+\b` | GitLab MR / Gerrit | `!42` |
+| `https?://\S+/(issues|pull|merge_requests|browse)/\S+` | URL | `.../issues/123` |
+
+Tracker type is auto-inferred from `git remote get-url origin` (gitlab.com / github.com / atlassian.net) and the link shapes found. `--tracker` overrides.
+
+Commits with no detected link are **unlinked**; skipped unless `--include-unlinked` (then only those that are reverts or touch ≥3 subsystems are kept).
+
+#### Phase 4: Cluster into Change Stories
+
+Group commits by issue key. One issue key → one candidate ChDR. For URL-only links, normalize to the issue number. Merge subject + body text across the cluster as the raw rationale corpus.
+
+#### Phase 5: Best-Effort Issue Fetch
+
+For each cluster, fetch the issue title + body summary as **Context** (the requirement that motivated the change). Best-effort, never blocking:
+
+- **GitLab**: use the configured GitLab MCP tools (`gitlab_get_issue` by project+iid). If unavailable, try `glab issue view`.
+- **GitHub**: `gh issue view <num> --json title,body` (if `gh` is authenticated).
+- **JIRA / unreachable**: link-only — record the URL as evidence, Context comes from commit messages alone.
+
+`--no-fetch` skips this phase entirely. Any fetch failure degrades to commit-message context (do not abort).
+
+**Security**: issue bodies may contain sensitive detail. Summarize the requirement in 1-3 sentences; do not paste raw issue bodies verbatim into the ChDR. The human gate (`/change-clarify`) reviews before promotion.
+
+#### Phase 6: Detect Revert/Fix Chains (first-class)
+
+Across the whole window (independent of issue links):
+
+- **Reverts**: `git log --grep='^Revert "' --pretty=format:'%H %s'` and `git log --grep='revert' -i`. For each reverted original commit, record it as negative knowledge.
+- **Fix chains**: commits whose subject matches `fix(?!ed)?\b` or `hotfix` that touch the same files as an earlier commit in the window — a follow-up fixing a regression. Record the pair (original, fix) as a consequence.
+
+Reverts and fix chains that have no issue link are still captured when `--include-unlinked` is set (they are the highest-value unlinked signal). When a revert/fix chain belongs to an issue-linked cluster, attach it to that cluster's `### Consequences`.
+
+#### Phase 7: Score & Prioritize
+
+Score each candidate (0.0–1.0):
+
+- subsystems touched (cross-cutting = higher)
+- diff size (larger = higher, capped)
+- has revert/fix-chain consequence (boost — negative knowledge)
+- has fetched issue context (boost — richer rationale)
+- recency (mild boost)
+
+Sort descending; take top `--limit` (default 20). Skip candidates with score below 0.2 (trivial).
+
+#### Phase 8: Generate ChDRs
+
+For each selected change story, write `{CHDR_DRAFTS_DIR}/ChDR-{NNN}.md`:
+
+```markdown
+## ChDR-NNN: [Title — from issue title or commit subject]
+
+### Status: **Discovered**
+
+### Date: [YYYY-MM-DD of most recent commit in cluster]
+
+### Source: Git history via /change-init
+
+### Issue Links: [keys/URLs, or "none detected"]
+
+### Commits: [sha list, abbreviated]
+
+### Target Module: `.adlc/memory/chdr/[slug].md`
+
+### Descriptor: One-line "when to consult this" summary for the chdr.md index.
+
+### Context
+[Why the change was made — issue title/body summary (1-3 sentences) + commit messages. Cite SHAs inline.]
+
+### Decision
+[What was decided/implemented — inferred from diffs. Mark confidence: HIGH/MEDIUM/LOW. Each claim cites its SHA/URL.]
+
+### Consequences
+[Reverts, follow-up fix chains, later modifications — negative knowledge. "None observed" if the cluster has no reversals.]
+
+### Evidence
+- `{sha}`: {commit subject}
+- {file/path}: {what changed}
+- {issue-url}: {title} (fetched | link-only)
+```
+
+**Rules**:
+
+- Every `### Decision` claim cites a SHA or URL (provenance — the context-poisoning circuit breaker).
+- "Reason unknown" is acceptable and preferred over invention.
+- Confidence is mandatory on Decision claims.
+
+Then regenerate `{CHDR_DRAFTS_DIR}/chdr.md` index by listing all `ChDR-*.md` files and building a markdown table from their single-line fields:
+
+```markdown
+# Change Decision Records (Drafts)
+
+## ChDR Index
+
+| ID | Status | Date | Issues | Commits | Descriptor |
+|----|--------|------|--------|---------|------------|
+| ChDR-001 | Discovered | 2026-08-16 | PROJ-123 | abc1234 | Why payments retries are capped at 3 |
+
+**Stats**: N entries | Last Updated: YYYY-MM-DD
+```
+
+#### Phase 9: Output Summary
+
+```markdown
+## Change-Init Summary
+
+- Scan window: [since/until or "last N commits"]
+- Commits scanned: N
+- Issue-linked commits: M (linkage rate: P%)
+- Clusters formed: K
+- Revert/fix chains detected: C
+- ChDRs generated: N (capped at --limit)
+- Output: `{REPO_ROOT}/.adlc/drafts/chdr/`
+```
+
+**Linkage rate** sets expectations about corpus quality (research shows rationale density varies widely by team discipline — 85–99% on disciplined projects like the Linux kernel, far lower elsewhere). Below ~30%, suggest `--include-unlinked` for the next run.
+
+### Key Rules
+
+#### Evidence-Based, Never Fabricated
+
+- Only document decisions inferable from commits + issues
+- Cite specific SHAs and/or issue URLs on every Decision claim
+- Mark confidence levels (HIGH/MEDIUM/LOW)
+- "Reason unknown" is acceptable; invention is not
+
+#### Non-Destructive
+
+- Do not overwrite existing ChDRs without approval
+- Preserve manually added content
+- Merge intelligently if a ChDR already exists for the same issue key
+
+#### Graceful Degradation
+
+- Not a git repo → exit cleanly, no empty drafts
+- Tracker unreachable → link-only evidence, proceed
+- Empty/terse commit messages → rely on diffs + issue fetch; if both absent, skip the cluster
+
+#### No Fabricated Rejection Rationale
+
+- For inferred decisions, use neutral "Observed Alternatives" framing
+- "We don't know why X wasn't chosen" is acceptable
+
+### Workflow Guidance & Transitions
+
+#### After `/change-init`
+
+**Required**: Run `/change-clarify` to validate discovered ChDRs.
+
+```text
+/change-init
+    ↓
+[Mine git history] → Detect issue links, cluster, infer decisions
+    ↓
+[Generate ChDRs] → Write to .adlc/drafts/chdr/ChDR-{NNN}.md (Discovered)
+    ↓
+[Run /change-clarify] → Validate and accept/reject ChDRs
+    ↓
+[Run /change-publish] → Promote accepted ChDRs to .adlc/memory/chdr/
+    ↓
+[team-boot] → Injects .adlc/memory/chdr.md index at next session start
+```
+
+## Next Steps
+
+After `init` completes, run `/change-clarify` to refine and validate the discovered ChDRs.
+
+## Verification
+
+- ChDRs written to `{REPO_ROOT}/.adlc/drafts/chdr/ChDR-{NNN}.md` with status **Discovered**.
+- Auto-generated `chdr.md` index exists in `{REPO_ROOT}/.adlc/drafts/chdr/`.
+- Every ChDR's `### Decision` claims cite at least one SHA or issue URL (provenance).
+- Revert/fix chains detected in the window appear in `### Consequences` (or "None observed").
+- Linkage-rate metric appears in the summary.
+- No existing ChDRs were overwritten without explicit approval.
+
+## Context
+
+$ARGUMENTS

--- a/skills/change/change-init/scripts/bash/setup-change-init.sh
+++ b/skills/change/change-init/scripts/bash/setup-change-init.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# setup-change-init.sh — Setup for change-init (self-contained)
+set -euo pipefail
+
+###############################################################################
+# Inline path resolution (no external helper dependency)
+###############################################################################
+
+resolve_project_root() {
+  local dir
+  dir="$(pwd)"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -d "${dir}/.adlc" ]]; then
+      echo "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+resolve_team_ai_directives() {
+  local project_root="$1"
+  local td="${TEAM_AI_DIRECTIVES:-}"
+  [[ -n "$td" ]] && { echo "$td"; return; }
+  if [[ -f "${project_root}/.adlc/init-options.json" ]]; then
+    td=$(python3 -c "
+import json
+try:
+    with open('${project_root}/.adlc/init-options.json') as f:
+        print(json.load(f).get('team_ai_directives', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+    [[ -n "$td" ]] && { echo "$td"; return; }
+  fi
+  echo "${project_root}/team-ai-directives"
+}
+
+resolve_branch() {
+  git branch --show-current 2>/dev/null || echo "unknown"
+}
+
+git_available() {
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo "true" || echo "false"
+}
+
+default_branch() {
+  # Try common primary branches, fall back to current branch name.
+  local b
+  for b in main master; do
+    if git show-ref --verify --quiet "refs/heads/${b}" 2>/dev/null; then
+      echo "$b"
+      return
+    fi
+  done
+  git branch --show-current 2>/dev/null || echo "unknown"
+}
+
+next_chdr_number() {
+  local dir="$1"
+  mkdir -p "$dir" 2>/dev/null || true
+  local max=0
+  for f in "$dir"/ChDR-*.md; do
+    [[ -f "$f" ]] || continue
+    local num
+    num=$(basename "$f" | sed -E 's/ChDR-([0-9]+).*/\1/')
+    [[ "$num" =~ ^[0-9]+$ ]] || continue
+    ((10#$num > max)) && max=$((10#$num))
+  done
+  printf '%03d' $((max + 1))
+}
+
+###############################################################################
+# Main
+###############################################################################
+
+PROJECT_ROOT=$(resolve_project_root)
+TEAM_AI_DIRECTIVES=$(resolve_team_ai_directives "$PROJECT_ROOT")
+BRANCH=$(resolve_branch)
+GIT_AVAILABLE=$(git_available)
+DEFAULT_BRANCH=$(default_branch)
+CHDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/chdr"
+CHANGE_STATE_FILE="${PROJECT_ROOT}/.adlc/change/state.json"
+
+mkdir -p "$CHDR_DRAFTS_DIR" "$(dirname "$CHANGE_STATE_FILE")" 2>/dev/null || true
+
+NEXT_CHDR=$(next_chdr_number "$CHDR_DRAFTS_DIR")
+EXISTING_CHDRS=$( { ls -1 "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+TD_CONFIGURED=$([[ -d "$TEAM_AI_DIRECTIVES" ]] && echo "true" || echo "false")
+
+python3 - "$PROJECT_ROOT" "$CHDR_DRAFTS_DIR" "$CHANGE_STATE_FILE" "$TEAM_AI_DIRECTIVES" "$BRANCH" "$NEXT_CHDR" "$EXISTING_CHDRS" "$TD_CONFIGURED" "$GIT_AVAILABLE" "$DEFAULT_BRANCH" << 'PY'
+import json, sys
+print(json.dumps({
+  "REPO_ROOT": sys.argv[1],
+  "CHDR_DRAFTS_DIR": sys.argv[2],
+  "CHANGE_STATE_FILE": sys.argv[3],
+  "TEAM_AI_DIRECTIVES": sys.argv[4],
+  "BRANCH": sys.argv[5],
+  "NEXT_CHDR": sys.argv[6],
+  "EXISTING_CHDRS": int(sys.argv[7]),
+  "TD_CONFIGURED": sys.argv[8] == "true",
+  "GIT_AVAILABLE": sys.argv[9] == "true",
+  "DEFAULT_BRANCH": sys.argv[10]
+}))
+PY

--- a/skills/change/change-init/scripts/powershell/setup-change-init.ps1
+++ b/skills/change/change-init/scripts/powershell/setup-change-init.ps1
@@ -1,0 +1,103 @@
+#!/usr/bin/env pwsh
+# setup-change-init.ps1 — Setup for change-init (self-contained)
+$ErrorActionPreference = "Stop"
+
+###############################################################################
+# Inline path resolution (no external helper dependency)
+###############################################################################
+
+function Resolve-ProjectRoot {
+    $dir = $PSScriptRoot
+    while ($dir -ne "") {
+        if (Test-Path (Join-Path $dir ".adlc")) { return $dir }
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if ($gitRoot) { return $gitRoot }
+    return (Get-Location).Path
+}
+
+function Resolve-TeamAiDirectives {
+    param([string]$ProjectRoot)
+    $td = $env:TEAM_AI_DIRECTIVES
+    if ($td) { return $td }
+    $initOpts = Join-Path $ProjectRoot ".adlc/init-options.json"
+    if (Test-Path $initOpts) {
+        try {
+            $config = Get-Content $initOpts -Raw | ConvertFrom-Json
+            if ($config.team_ai_directives) { return $config.team_ai_directives }
+        } catch {}
+    }
+    return (Join-Path $ProjectRoot "team-ai-directives")
+}
+
+function Resolve-Branch {
+    $b = git branch --show-current 2>$null
+    if ($b) { return $b }
+    return "unknown"
+}
+
+function Test-GitAvailable {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) { return "true" }
+    return "false"
+}
+
+function Get-DefaultBranch {
+    foreach ($b in @("main", "master")) {
+        git show-ref --verify --quiet "refs/heads/$b" 2>$null
+        if ($LASTEXITCODE -eq 0) { return $b }
+    }
+    $cur = git branch --show-current 2>$null
+    if ($cur) { return $cur }
+    return "unknown"
+}
+
+function Get-NextChdrNumber {
+    param([string]$Dir)
+    if (-not (Test-Path $Dir)) { New-Item -ItemType Directory -Path $Dir -Force | Out-Null }
+    $max = 0
+    Get-ChildItem -Path $Dir -Filter "ChDR-*.md" -ErrorAction SilentlyContinue | ForEach-Object {
+        if ($_.BaseName -match 'ChDR-(\d+)') {
+            $num = [int]$Matches[1]
+            if ($num -gt $max) { $max = $num }
+        }
+    }
+    return ('{0:D3}' -f ($max + 1))
+}
+
+###############################################################################
+# Main
+###############################################################################
+
+$ProjectRoot = Resolve-ProjectRoot
+$TeamAiDirectives = Resolve-TeamAiDirectives $projectRoot
+$Branch = Resolve-Branch
+$GitAvailable = Test-GitAvailable
+$DefaultBranch = Get-DefaultBranch
+$ChdrDraftsDir = Join-Path $projectRoot ".adlc/drafts/chdr"
+$ChangeStateFile = Join-Path $projectRoot ".adlc/change/state.json"
+
+$StateDir = Split-Path $ChangeStateFile -Parent
+if (-not (Test-Path $ChdrDraftsDir)) { New-Item -ItemType Directory -Path $ChdrDraftsDir -Force | Out-Null }
+if (-not (Test-Path $StateDir)) { New-Item -ItemType Directory -Path $StateDir -Force | Out-Null }
+
+$NextChdr = Get-NextChdrNumber $ChdrDraftsDir
+$ExistingChdrs = @(Get-ChildItem -Path $ChdrDraftsDir -Filter "ChDR-*.md" -ErrorAction SilentlyContinue).Count
+$TdConfigured = if (Test-Path $TeamAiDirectives) { "true" } else { "false" }
+
+$output = @{
+    REPO_ROOT = $projectRoot
+    CHDR_DRAFTS_DIR = $ChdrDraftsDir
+    CHANGE_STATE_FILE = $ChangeStateFile
+    TEAM_AI_DIRECTIVES = $TeamAiDirectives
+    BRANCH = $Branch
+    NEXT_CHDR = $NextChdr
+    EXISTING_CHDRS = $ExistingChdrs
+    TD_CONFIGURED = ($TdConfigured -eq "true")
+    GIT_AVAILABLE = ($GitAvailable -eq "true")
+    DEFAULT_BRANCH = $DefaultBranch
+}
+$output | ConvertTo-Json -Compress

--- a/skills/change/change-publish/SKILL.md
+++ b/skills/change/change-publish/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: change-publish
+description: Promote accepted Change Decision Records (ChDRs) from drafts to project memory at .adlc/memory/chdr/, write OKF-style frontmatter, and regenerate the boot-facing .adlc/memory/chdr.md index that team-boot injects at session start. Use after /change-clarify has accepted ChDRs.
+disable-model-invocation: true
+---
+
+# change-publish
+
+## What this skill does
+
+Compile **accepted ChDRs** into the project's memory layer at `{REPO_ROOT}/.adlc/memory/chdr/`:
+
+- Validate accepted ChDRs (status + provenance on Decision claims)
+- Write each promoted ChDR to `.adlc/memory/chdr/ChDR-{NNN}.md` with OKF-style frontmatter
+- Regenerate `{REPO_ROOT}/.adlc/memory/chdr.md` — the **boot-facing index** that `team-boot` injects into the session-start context (same convention as `pdr.md`/`adr.md`)
+- Mark source drafts `### Status: **Published**`
+
+Unlike `/levelup-publish` (which opens a PR against team-ai-directives), `change-publish` writes **project-local memory** — ChDRs describe this repo's evolution and fail the team-wide signal gate. No PR is created; the user commits via their normal flow.
+
+**This skill does not run until ChDRs have been accepted via `/change-clarify`.**
+
+## When to use
+
+- **After `/change-clarify`**: accepted ChDRs need promotion to memory
+- **After re-running `/change-init`**: new accepted ChDRs to add to the memory index
+
+### When NOT to use
+
+- **No accepted ChDRs**: run `/change-clarify` first
+- **Discovering ChDRs**: use `/change-init`
+- **Reviewing ChDRs**: use `/change-clarify`
+
+## Process
+
+### User Input
+
+```text
+$ARGUMENTS
+```
+
+**Examples**:
+
+- `"ChDR-001 ChDR-003"` — promote only specific ChDRs
+- Empty input: promote all accepted ChDRs
+
+### Role & Context
+
+You are acting as a **Memory Publisher** — moving accepted ChDRs from local drafts to durable project memory. Your role:
+
+- Validate provenance one more time (the poisoning circuit breaker — a promoted unprovenanced decision poisons every future session via team-boot)
+- Write promoted records with frontmatter that `team-boot` can index
+- Regenerate the `chdr.md` index so the next session start sees the new decisions
+
+### Outline
+
+1. **Environment Setup** (Phase 0): resolve paths, list accepted ChDRs
+2. **Prerequisites Check** (Phase 1): ensure accepted ChDRs exist
+3. **Provenance Validation** (Phase 2): re-verify every Decision claim has SHA/URL
+4. **Duplicate Check** (Phase 3): skip ChDRs already in memory with same issue key
+5. **Memory Record Generation** (Phase 4): write `.adlc/memory/chdr/ChDR-{NNN}.md`
+6. **Index Regeneration** (Phase 5): rebuild `.adlc/memory/chdr.md` (boot-facing)
+7. **Draft Status Update** (Phase 6): mark promoted drafts `Published`
+8. **Summary** (Phase 7): report results
+
+### Execution Steps
+
+#### Phase 0: Environment Setup
+
+Run:
+
+```bash
+scripts/bash/setup-change-publish.sh
+```
+
+Parse JSON for `REPO_ROOT`, `CHDR_DRAFTS_DIR`, `MEMORY_DIR`, `MEMORY_INDEX`, `ACCEPTED_CHDRS`.
+
+**If the setup script is unavailable or fails**, resolve manually:
+
+1. `REPO_ROOT` — walk up to `.adlc/`, or `git rev-parse --show-toplevel`.
+2. `CHDR_DRAFTS_DIR` — `REPO_ROOT/.adlc/drafts/chdr`
+3. `MEMORY_DIR` — `REPO_ROOT/.adlc/memory/chdr`
+4. `MEMORY_INDEX` — `REPO_ROOT/.adlc/memory/chdr.md` (same level as `pdr.md`/`adr.md`)
+5. `ACCEPTED_CHDRS` — `grep -l '^### Status: \*\*Accepted\*\*' CHDR_DRAFTS_DIR/ChDR-*.md`
+
+#### Phase 1: Prerequisites Check
+
+If `ACCEPTED_CHDRS` is empty:
+
+```text
+No accepted ChDRs found.
+Run /change-clarify to accept ChDRs first.
+```
+
+#### Phase 2: Provenance Validation
+
+For each accepted ChDR, re-verify: every non-trivial sentence in `### Decision` references a SHA (`\b[0-9a-f]{7,40}\b`) or URL (`https?://`). Skip ChDRs that fail provenance — they cannot be promoted (poisoning risk):
+
+```markdown
+## Provenance Validation
+
+**Passing**: N | **Skipped**: M
+
+### Skipped ChDRs
+
+| ChDR | Reason |
+|---|---|
+| ChDR-XXX | Decision claim lacks SHA/URL provenance |
+```
+
+Skipped ChDRs remain `Accepted` in drafts for the user to fix.
+
+#### Phase 3: Duplicate Check
+
+For each passing ChDR, check if a memory record already exists with the same `### Issue Links` key. If so, skip (or offer to merge) — do not create duplicates.
+
+#### Phase 4: Memory Record Generation
+
+For each accepted ChDR, write `{MEMORY_DIR}/ChDR-{NNN}.md`:
+
+```markdown
+---
+type: ChDR
+title: {title from heading}
+description: {descriptor from draft}
+resource: ./.adlc/memory/chdr/ChDR-{NNN}.md
+tags: [chdr]
+generated:
+  by: agent:change-publish
+  at: {today}T00:00:00Z
+id: ChDR-{NNN}
+created: {date from draft}
+verified:
+  - by: agent:change-publish
+    at: {today}T00:00:00Z
+status: stable
+stale_after: 365d
+sources:
+  - id: {sha}
+    resource: git:{sha}
+    title: {commit subject}
+  - id: {issue-key}
+    resource: {issue-url}
+    title: {issue title}
+---
+
+# {Title}
+
+{Content from draft — Context, Decision, Consequences, Evidence verbatim}
+
+## Source
+
+Promoted from: .adlc/drafts/chdr/ChDR-{NNN}.md
+```
+
+#### Phase 5: Index Regeneration (boot-facing)
+
+**This is the integration point with `team-boot`.** Regenerate `{MEMORY_INDEX}` (`{REPO_ROOT}/.adlc/memory/chdr.md`) by listing all `ChDR-*.md` files in `{MEMORY_DIR}` and building a markdown table whose rows start with `| ChDR-` (the awk filter `team-boot` uses):
+
+```markdown
+# Change Decision Records (Memory)
+
+## ChDR Index
+
+| ID | Title | Status | Date | Issues | Commits | Descriptor |
+|----|-------|--------|------|--------|---------|------------|
+| ChDR-001 | Why payments retries are capped at 3 | stable | 2026-08-16 | PROJ-123 | abc1234 | Consult before changing retry config |
+
+**Stats**: N entries | Last Updated: YYYY-MM-DD
+```
+
+`team-boot`'s `boot.sh`/`boot.ps1` reads this file and emits a `## ChDR Index` section + `CHDR_COUNT` into the session-start context, alongside the PDR/ADR indexes.
+
+#### Phase 6: Draft Status Update
+
+For each promoted ChDR, update the draft file's status to `### Status: **Published**` and add:
+
+```markdown
+### Promotion
+
+- **Date**: [YYYY-MM-DD]
+- **Memory path**: .adlc/memory/chdr/ChDR-{NNN}.md
+```
+
+#### Phase 7: Summary
+
+```markdown
+## Change-Publish Summary
+
+**ChDRs Promoted**: N
+**ChDRs Skipped (provenance)**: M
+**ChDRs Skipped (duplicate)**: K
+
+### Artifacts
+
+| Type | Count |
+|---|---|
+| Memory records (.adlc/memory/chdr/) | N |
+| Boot index (.adlc/memory/chdr.md) | 1 (regenerated) |
+
+### Next Steps
+
+The next session start (`team-boot`) will inject the ChDR index into context.
+Commit `.adlc/memory/chdr/` and `.adlc/memory/chdr.md` via your normal flow.
+```
+
+### Key Rules
+
+#### Provenance Before Promotion
+
+- A promoted unprovenanced Decision poisons every future session (team-boot injects it)
+- Re-validate provenance at publish time, not just at clarify
+
+#### Project-Local, Not Team-Wide
+
+- ChDRs publish to `.adlc/memory/`, not team-ai-directives
+- No PR created — user commits via normal flow
+- ChDRs fail the levelup "team-wide applicability" signal gate by design
+
+#### Index Format Must Match team-boot
+
+- Rows MUST start with `| ChDR-` (the awk/regex filter in boot.sh/boot.ps1)
+- File MUST be at `.adlc/memory/chdr.md` (same level as `pdr.md`/`adr.md`)
+
+### Workflow Guidance & Transitions
+
+#### After `/change-publish`
+
+```text
+/change-init → /change-clarify → /change-publish
+    ↓
+[team-boot] → injects .adlc/memory/chdr.md index at next session start
+    ↓
+[Agent consults ChDRs on demand when touching affected code]
+```
+
+Re-run `/change-init` periodically to mine new history; new accepted ChDRs are added to memory and the index is regenerated.
+
+## Next Steps
+
+Commit the memory directory. The next session automatically sees the ChDR index via `team-boot`.
+
+## Verification
+
+- All accepted ChDRs with provenance promoted to `.adlc/memory/chdr/ChDR-*.md`.
+- `.adlc/memory/chdr.md` index regenerated with rows starting `| ChDR-`.
+- Promoted drafts marked `### Status: **Published**`.
+- No unprovenanced ChDRs were promoted.
+- No duplicate issue keys in memory.
+
+## Context
+
+$ARGUMENTS

--- a/skills/change/change-publish/scripts/bash/setup-change-publish.sh
+++ b/skills/change/change-publish/scripts/bash/setup-change-publish.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# setup-change-publish.sh — Setup for change-publish (self-contained)
+set -euo pipefail
+
+resolve_project_root() {
+  local dir
+  dir="$(pwd)"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -d "${dir}/.adlc" ]]; then
+      echo "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+PROJECT_ROOT=$(resolve_project_root)
+CHDR_DRAFTS_DIR="${PROJECT_ROOT}/.adlc/drafts/chdr"
+MEMORY_DIR="${PROJECT_ROOT}/.adlc/memory/chdr"
+MEMORY_INDEX="${PROJECT_ROOT}/.adlc/memory/chdr.md"
+
+mkdir -p "$MEMORY_DIR" 2>/dev/null || true
+
+# Accepted ChDR ids (filenames) in drafts
+ACCEPTED_CHDRS=$( { grep -l '^### Status: \*\*Accepted\*\*' "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | xargs -r -n1 basename 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+ACCEPTED_COUNT=$( { grep -l '^### Status: \*\*Accepted\*\*' "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+PUBLISHED_COUNT=$( { grep -l '^### Status: \*\*Published\*\*' "$CHDR_DRAFTS_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+MEMORY_COUNT=$( { ls -1 "$MEMORY_DIR"/ChDR-*.md 2>/dev/null || true; } | wc -l | tr -d ' ')
+MEMORY_INDEX_EXISTS=$([[ -f "$MEMORY_INDEX" ]] && echo "true" || echo "false")
+
+python3 - "$PROJECT_ROOT" "$CHDR_DRAFTS_DIR" "$MEMORY_DIR" "$MEMORY_INDEX" "$ACCEPTED_CHDRS" "$ACCEPTED_COUNT" "$PUBLISHED_COUNT" "$MEMORY_COUNT" "$MEMORY_INDEX_EXISTS" << 'PY'
+import json, sys
+accepted = sys.argv[5].split() if sys.argv[5].strip() else []
+print(json.dumps({
+  "REPO_ROOT": sys.argv[1],
+  "CHDR_DRAFTS_DIR": sys.argv[2],
+  "MEMORY_DIR": sys.argv[3],
+  "MEMORY_INDEX": sys.argv[4],
+  "ACCEPTED_CHDRS": accepted,
+  "ACCEPTED_COUNT": int(sys.argv[6]),
+  "PUBLISHED_COUNT": int(sys.argv[7]),
+  "MEMORY_COUNT": int(sys.argv[8]),
+  "MEMORY_INDEX_EXISTS": sys.argv[9] == "true"
+}))
+PY

--- a/skills/change/change-publish/scripts/powershell/setup-change-publish.ps1
+++ b/skills/change/change-publish/scripts/powershell/setup-change-publish.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+# setup-change-publish.ps1 — Setup for change-publish (self-contained)
+$ErrorActionPreference = "Stop"
+
+function Resolve-ProjectRoot {
+    $dir = $PSScriptRoot
+    while ($dir -ne "") {
+        if (Test-Path (Join-Path $dir ".adlc")) { return $dir }
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    $gitRoot = git rev-parse --show-toplevel 2>$null
+    if ($gitRoot) { return $gitRoot }
+    return (Get-Location).Path
+}
+
+$ProjectRoot = Resolve-ProjectRoot
+$ChdrDraftsDir = Join-Path $projectRoot ".adlc/drafts/chdr"
+$MemoryDir = Join-Path $projectRoot ".adlc/memory/chdr"
+$MemoryIndex = Join-Path $projectRoot ".adlc/memory/chdr.md"
+
+if (-not (Test-Path $MemoryDir)) { New-Item -ItemType Directory -Path $MemoryDir -Force | Out-Null }
+
+$AcceptedChdrs = @()
+$AcceptedCount = 0
+$PublishedCount = 0
+$draftFiles = @(Get-ChildItem -Path $ChdrDraftsDir -Filter "ChDR-*.md" -ErrorAction SilentlyContinue)
+foreach ($f in $draftFiles) {
+    $content = Get-Content $f.FullName -Raw
+    if ($content -match '### Status: \*\*Accepted\*\*') {
+        $AcceptedChdrs += $f.Name
+        $AcceptedCount++
+    } elseif ($content -match '### Status: \*\*Published\*\*') {
+        $PublishedCount++
+    }
+}
+$MemoryCount = @(Get-ChildItem -Path $MemoryDir -Filter "ChDR-*.md" -ErrorAction SilentlyContinue).Count
+$MemoryIndexExists = Test-Path $MemoryIndex
+
+$output = @{
+    REPO_ROOT = $projectRoot
+    CHDR_DRAFTS_DIR = $ChdrDraftsDir
+    MEMORY_DIR = $MemoryDir
+    MEMORY_INDEX = $MemoryIndex
+    ACCEPTED_CHDRS = $AcceptedChdrs
+    ACCEPTED_COUNT = $AcceptedCount
+    PUBLISHED_COUNT = $PublishedCount
+    MEMORY_COUNT = $MemoryCount
+    MEMORY_INDEX_EXISTS = $MemoryIndexExists
+}
+$output | ConvertTo-Json -Compress

--- a/skills/levelup/levelup-init/SKILL.md
+++ b/skills/levelup/levelup-init/SKILL.md
@@ -36,6 +36,7 @@ This skill focuses on **current state analysis** — what IS reusable, not what 
 ### When NOT to use
 
 - **Greenfield projects**: Use `/levelup-specify` after implementing a feature
+- **Mining git history / issue-linked changes**: Use `/change-init` to recover past decisions from commits + issue trackers
 - **CDRs already exist**: If `.adlc/drafts/cdr/` has pending CDRs, use `/levelup-clarify` to review
 - **Routine team AI directives health checks**: Use `/team-repair` for re-indexing and conflict scanning
 

--- a/skills/levelup/levelup-specify/SKILL.md
+++ b/skills/levelup/levelup-specify/SKILL.md
@@ -35,6 +35,7 @@ This skill focuses on **session-level learnings** — what reusable knowledge em
 ### When NOT to use
 
 - **Brownfield projects**: Use `/levelup-init` to scan existing code
+- **Mining git history / issue-linked changes**: Use `/change-init` to recover past decisions from commits + issue trackers
 - **Before work is done**: Run this after completing the implementation
 - **Routine team AI directives validation**: Use `/team-repair` for health checks
 

--- a/skills/team/team-boot/SKILL.md
+++ b/skills/team/team-boot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-boot
-description: Bootstrap the session with team AI directives context (constitution, CDR index, PDR/ADR indexes, skill registry). Runs automatically at session start via the event hook.
+description: Bootstrap the session with team AI directives context (constitution, CDR index, PDR/ADR/ChDR indexes, skill registry). Runs automatically at session start via the event hook.
 scripts:
   sh: scripts/boot.sh
   ps: scripts/boot.ps1
@@ -24,7 +24,7 @@ of the bootstrap loop.
 
 The `session_start` event hook runs `scripts/boot.sh` (POSIX) or
 `scripts/boot.ps1` (Windows), which reads `.adlc/init-options.json`,
-assembles the context block (constitution, CDR index, PDR/ADR indexes,
+assembles the context block (constitution, CDR index, PDR/ADR/ChDR indexes,
 skill registry), and outputs it to stdout. The plugin caches the result
 and pushes it into the system prompt on every step (idempotent — same
 cached content, no accumulation).
@@ -37,7 +37,7 @@ cached content, no accumulation).
 2. If unconfigured (missing, `null`, or path doesn't exist): invoke the
    `team-setup` skill.
 3. If configured: read and assemble the constitution, CDR.md index table,
-   PDR/ADR indexes, and `.skills.json` into your context.
+   PDR/ADR/ChDR indexes, and `.skills.json` into your context.
 4. The CDR index is your catalog — read full module bodies on demand
    when a task matches a CDR descriptor.
 

--- a/skills/team/team-boot/scripts/boot.ps1
+++ b/skills/team/team-boot/scripts/boot.ps1
@@ -122,6 +122,28 @@ Write-Output ""
 Write-Output "_Total: $AdrCount ADR entries available._"
 Write-Output ""
 
+# ChDR Index — from project memory (Published Change Decision Records mined by /change-init)
+Write-Output "## ChDR Index"
+$ChdrCount = 0
+$chdrPath = ".adlc/memory/chdr.md"
+if (Test-Path $chdrPath) {
+    $chdrLines = Get-Content $chdrPath | Where-Object { $_ -match '^\| ChDR' }
+    $ChdrCount = $chdrLines.Count
+    $chdrLines | ForEach-Object {
+        $cols = $_ -split '\|'
+        if ($cols.Count -ge 6) {
+            $id = $cols[1].Trim()
+            $title = $cols[2].Trim()
+            $date = $cols[4].Trim()
+            $desc = $cols[5].Trim()
+            Write-Output "| $id | $date | $title | $desc |"
+        }
+    }
+}
+Write-Output ""
+Write-Output "_Total: $ChdrCount ChDR entries available._"
+Write-Output ""
+
 # Skills — names + descriptions only (lean)
 Write-Output "## Available Skills"
 $skillsPath = Join-Path $TEAM_AI_DIRECTIVES ".skills.json"
@@ -159,6 +181,6 @@ Write-Output "| ID | Name | Type | Relevance |"
 Write-Output "|----|------|------|-----------|"
 Write-Output "| CDR-YYYY-NNN | <name> | <type> | <relevance> |"
 Write-Output ""
-Write-Output "Plus: _Searched $CdrCount CDR entries, $PdrCount PDR entries, $AdrCount ADR entries, $SkillTotal skills, J matched._"
+Write-Output "Plus: _Searched $CdrCount CDR entries, $PdrCount PDR entries, $AdrCount ADR entries, $ChdrCount ChDR entries, $SkillTotal skills, J matched._"
 Write-Output "**J MUST equal the number of rows in your table; if no CDRs/skills genuinely match, show an empty table with 0 matched (do not copy a hard-coded CDR or inflate the count).**"
 Write-Output "</EXTREMELY_IMPORTANT>"

--- a/skills/team/team-boot/scripts/boot.sh
+++ b/skills/team/team-boot/scripts/boot.sh
@@ -96,6 +96,18 @@ echo ""
 echo "_Total: $ADR_COUNT ADR entries available._"
 echo ""
 
+# ChDR Index — from project memory (Published Change Decision Records mined by /change-init)
+echo "## ChDR Index"
+CHDR_COUNT=0
+if [ -f ".adlc/memory/chdr.md" ]; then
+  CHDR_COUNT=$(awk '/^\| ChDR/ {count++} END {print count+0}' ".adlc/memory/chdr.md" 2>/dev/null || true)
+  [[ "$CHDR_COUNT" =~ ^[0-9]+$ ]] || CHDR_COUNT=0
+  awk -F'|' '/^\| ChDR/ {gsub(/^ +| +$/,"",$2); gsub(/^ +| +$/,"",$3); gsub(/^ +| +$/,"",$4); gsub(/^ +| +$/,"",$5); print "| " $2 " | " $4 " | " $3 " | " $5 " |"}' ".adlc/memory/chdr.md" 2>/dev/null || true
+fi
+echo ""
+echo "_Total: $CHDR_COUNT ChDR entries available._"
+echo ""
+
 # Skills — names + descriptions only (lean)
 echo "## Available Skills"
 SKILL_DEFAULT_COUNT=$(jq -r '.default | length' "$TEAM_AI_DIRECTIVES/.skills.json" 2>/dev/null || true)
@@ -130,6 +142,6 @@ echo "| ID | Name | Type | Relevance |"
 echo "|----|------|------|-----------|"
 echo "| CDR-YYYY-NNN | <name> | <type> | <relevance> |"
 echo ""
-echo "Plus: _Searched $CDR_COUNT CDR entries, $PDR_COUNT PDR entries, $ADR_COUNT ADR entries, $SKILL_TOTAL skills, J matched._"
+echo "Plus: _Searched $CDR_COUNT CDR entries, $PDR_COUNT PDR entries, $ADR_COUNT ADR entries, $CHDR_COUNT ChDR entries, $SKILL_TOTAL skills, J matched._"
 echo "**J MUST equal the number of rows in your table; if no CDRs/skills genuinely match, show an empty table with 0 matched (do not copy a hard-coded CDR or inflate the count).**"
 echo "</EXTREMELY_IMPORTANT>"

--- a/skills/team/team-discover/SKILL.md
+++ b/skills/team/team-discover/SKILL.md
@@ -40,8 +40,8 @@ verifying which directives apply). It is not required for normal operation.
 |----|--------|------|------------|-----------|
 | CDR-2026-003 | context_modules/personas/admin.md | Persona | Admin persona | High |
 
-6. Include PDR/ADR matches from project indexes if relevant.
-7. Include: `_Searched N CDR entries, M PDR entries, K ADR entries, J matches found._`
+6. Include PDR/ADR/ChDR matches from project indexes if relevant.
+7. Include: `_Searched N CDR entries, M PDR entries, K ADR entries, C ChDR entries, J matches found._`
 
 ## Unconfigured projects
 

--- a/tests/unit/test_team_boot_setup_flow.py
+++ b/tests/unit/test_team_boot_setup_flow.py
@@ -103,6 +103,33 @@ def test_boot_ps1_context_contract_integrity():
     assert "targeted file searches" in BOOT_PS1
 
 
+def test_boot_sh_includes_chdr_index_section():
+    """boot.sh must inject a ChDR Index section from .adlc/memory/chdr.md.
+
+    Change Decision Records (mined by /change-init, promoted by /change-publish)
+    live in project memory; team-boot surfaces their index at session start
+    alongside the PDR/ADR indexes.
+    """
+    assert "## ChDR Index" in BOOT_SH
+    assert ".adlc/memory/chdr.md" in BOOT_SH
+    # Counts line must include ChDR so the Team Context in Use summary is accurate
+    assert "ChDR entries" in BOOT_SH
+
+
+def test_boot_ps1_includes_chdr_index_section():
+    """boot.ps1 must inject a ChDR Index section from .adlc/memory/chdr.md."""
+    assert "## ChDR Index" in BOOT_PS1
+    assert ".adlc/memory/chdr.md" in BOOT_PS1
+    assert "ChdrCount" in BOOT_PS1
+
+
+def test_boot_counts_line_includes_chdr():
+    """The Searched...counts line in both boot scripts must include the ChDR count."""
+    assert "ChDR entries" in BOOT_SH
+    assert "$CHDR_COUNT" in BOOT_SH
+    assert "$ChdrCount" in BOOT_PS1
+
+
 def test_team_boot_sh_unconfigured_warns_user():
     """boot.sh unconfigured output must warn the user, not instruct the LLM."""
     assert "not configured" in BOOT_SH


### PR DESCRIPTION
## What

New `change-*` skill family mines the **why** behind how code came to be, recovered from commit messages + linked issue trackers — a third discovery source alongside `levelup-init` (code scan) and `levelup-specify` (session). Plus `team-boot` now injects the ChDR index at session start.

## Why

Coding agents see only current state; the empirically hardest developer questions are about rationale (LaToza et al. ICSE 2006; Ko et al. ICSE 2007). The rationale already lives in commits + linked issues and is extractable (CoMRAT, MSR 2025: 85–99% of commits in disciplined projects contain rationale; DRMiner, ASE 2024 showed mined rationale helps automated program repair). This fills a gap none of the existing levelup skills touches: **historical negative knowledge** (reverts, fix chains) and **requirement linkage** — recovering decisions that evaporated before any documentation discipline existed.

## Changes

### New `change-*` family (`skills/change/`)
- **`change-init`** — scans a `git log` window; auto-detects issue links (JIRA keys, GitHub/GitLab `#NNN`, MR `!NNN`, issue URLs); clusters commits by issue key into change stories; best-effort fetches issue context (GitLab via MCP, GitHub via `gh`, else link-only); treats **revert/fix chains as first-class negative knowledge**; writes `ChDR-{NNN}.md` drafts (status Discovered) with **mandatory SHA/URL provenance on every Decision claim** (the context-poisoning circuit-breaker); summary includes a linkage-rate metric.
- **`change-clarify`** — one-ChDR-at-a-time human gate (Accept/Reject/Defer/Accept-all), provenance check rejects unprovenanced inferred rationale.
- **`change-publish`** — promotes accepted ChDRs to `.adlc/memory/chdr/` and regenerates the boot-facing `.adlc/memory/chdr.md` index.

### `team-boot` integration
- `boot.sh` / `boot.ps1` emit a `## ChDR Index` section reading `.adlc/memory/chdr.md` (same convention as `pdr.md`/`adr.md`); `CHDR_COUNT` added to the `_Searched…_` counts line.
- `team-boot/SKILL.md` description updated to mention ChDR indexes.
- `team-discover/SKILL.md` includes ChDR matches + extended counts line.
- Next session start in any repo with published ChDRs surfaces them automatically.

### Eval coverage (CONTRIBUTING requirement)
- New `evals/promptfoo/graders/check_chdr_format.py` + `tests/test_check_chdr_format.py` (6 cases) + EVAL-006 goldset criterion — binary checks: required sections (`Context`/`Decision`/`Consequences`/`Evidence`), ≥1 commit SHA, issue link or explicit "no linked issue" marker, Decision provenance.

### Bookkeeping
- `README.md`: new "### Change (ChDRs)" section, repo-layout tree, workflow diagram line.
- `CHANGELOG.md`: `[0.26.0]` entry.
- `levelup-init` / `levelup-specify`: "When NOT to use" pointer to `/change-init`.

## Design decisions

- **Project-local memory, not team-ai-directives**: ChDRs describe one repo's evolution and fail the levelup "team-wide applicability" signal gate. They publish to `.adlc/memory/chdr/` (mirrors PDR promotion); no PR is created by `change-publish`.
- **Provenance is non-negotiable**: an unprovenanced inferred rationale is context poisoning (worse than no rationale). Enforced at clarify, re-validated at publish, and asserted by the grader.
- **No eval-CDR pairing in v1**: keeps scope tight; `--with-evals` is a future option.
- Out of scope: team-ai-directives publication, `team-repair` ChDR indexing, JIRA API fetch (link-only).

## Verification

- `pytest tests/unit/` → **96 passed** (auto-discovered setup-script sandbox tests run all 3 new `setup-change-*.sh`; playbook-integrity frontmatter/parity; dot-notation guard; boot contract; grader).
- End-to-end smoke: `init` draft → `clarify` accept → `publish` to memory → `team-boot` injected the ChDR index correctly; grader passed on the mined ChDR.
- `bash -n` clean on all new scripts; mirrors to `.agents/skills/` byte-identical to source.

## Checklist

- [x] Tests added (boot assertions + grader + goldset criterion)
- [x] `README.md` and `CHANGELOG.md` updated
- [x] Skill conventions followed (frontmatter, 2-level depth, self-contained setup scripts)
- [x] Eval coverage per CONTRIBUTING
- [ ] Issue opened first (CONTRIBUTING asks new skills be agreed in an issue — opening one for record; scope is contained and follows the existing levelup/architect/product family pattern)