### PR TITLE
release: 0.26.1 — How it works + Basic Workflow sections in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2026-08-20
+
+### Added
+
+- **"How it works" + "The Basic Workflow" sections in README** (`README.md`): two new top-level sections, placed between "A note on context stuffing" and "Install", that surface the end-to-end arc before the install/reference walls — `team-boot` session-start index injection (~hundred tokens, full rules pulled on demand) → `team-setup`/`team-constitution` on unconfigured projects → `mission-brief` spec contract and `specify → plan → implement ↔ converge` loop (gates, circuit breaker, resume, audit trail) with universal skill scanning (this repo + superpowers + spec-kit + your own) → `product-*`/`architect-*` PDR/ADR compilation into `PRD.md`/`AD.md` → `evals-*` binary Tier 1 + LLM Tier 2 graders with holdout/TPR/TNR/SLA, ending at a human-reviewed PR → `levelup-specify` CDR capture back to the team repo → `team-repair --build-to-delete` rule pruning. "The Basic Workflow" is an 8-step numbered list with bolded skill names and a closing "skills trigger automatically — mandatory lifecycle, not suggestions" line. Modeled on the [superpowers](https://github.com/obra/superpowers) README's "How it works" / "Basic Workflow" structure. Tone matches the existing technical README; the collapsible `Workflows` `<details>` block and `Reference` table are unchanged (they hold the detailed per-lifecycle chains; the new sections are the high-level summary). Documentation-only; PATCH bump per `RELEASE.md`.
+
 ## [0.26.0] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,6 +92,83 @@ it: agents get an index by default and pull full rules only when relevant. If
 your instinct is "more rules in context don't work" — we agree. That's the
 design.
 
+## How it works
+
+It starts the moment you open a session. `team-boot` fires via the
+`session_start` event hook and injects a lean index — your team's
+constitution, CDR index, PDR/ADR indexes, and skills registry — roughly a
+hundred tokens of names and one-line descriptors. Not the rules themselves.
+When the active task matches a rule, the agent pulls that rule's full text on
+demand. A task touching SQL loads the SQL rule; nothing else does.
+
+On an unconfigured project, `team-boot` points you to `/team-setup`, which
+clones, links, or scaffolds your team-ai-directives repo. `team-constitution`
+fills in your principles.
+
+When you ask it to build something, it doesn't jump to code. `mission-brief`
+forces a contract first — goal, constraints, non-goals, success criteria —
+then generates an ordered step list and walks `specify → plan → implement ↔
+converge`, with gates, a circuit breaker, resume, and an audit trail. At
+mission start it scans installed skills directories, reads each `SKILL.md`
+frontmatter, and hands the inventory to the subagent; the model picks the
+skill that fits each step — this repo's `product-specify`, superpowers'
+`brainstorming`, spec-kit's commands, or your own.
+
+For new products, `product-specify` captures Product Decision Records (PDRs),
+`product-clarify` refines them, and `product-implement` compiles them into
+`PRD.md`. The `architect-*` skills do the same for Architecture Decision
+Records (ADRs, Rozanski & Woods viewpoints) and compose them into `AD.md`.
+
+The `evals` skills build executable evaluation suites — binary graders
+(Tier 1, plain assertions) for anything code can check, LLM judges (Tier 2)
+only for what static checks can't. `evals-validate` runs the pyramid with
+holdout splits, TPR/TNR, and SLA headroom. Nothing auto-merges; the pipeline
+ends at a PR a human reviews.
+
+When a session surfaces a hard-won fix, `levelup-specify` extracts it as a
+Context Directive Record (CDR) — with a paired eval CDR — and commits it back
+to the team repo. The next session starts smarter.
+
+Rules rot, so `team-repair --build-to-delete` re-runs evals *without* a rule;
+if the model passes anyway, the rule is proposed for deletion. Rules should
+shrink over time, not grow.
+
+And because the skills trigger automatically from the index, you don't do
+anything special once they're installed. Your coding agent just has your
+team's context.
+
+## The Basic Workflow
+
+1. **team-boot** — auto-runs at session start (event hook); injects the
+   directives index (constitution, CDR index, PDR/ADR indexes, skills
+   registry). Full rules pulled on demand when the task matches.
+2. **team-setup** — on an unconfigured project, clones/links/scaffolds the
+   team-ai-directives repo. **team-constitution** fills in your principles.
+3. **mission-brief** — before code, forces a spec contract (goal, constraints,
+   non-goals, success criteria), then walks `specify → plan → implement ↔
+   converge` with gates, circuit breaker, resume, and audit trail.
+4. **product-specify / product-init** — greenfield/brownfield capture of
+   Product Decision Records (PDRs). → **product-clarify** refines →
+   **product-implement** generates `PRD.md` → **product-analyze** checks
+   consistency.
+5. **architect-specify / architect-init** — same shape for Architecture
+   Decision Records (ADRs, Rozanski & Woods). → **architect-clarify** →
+   **architect-implement** generates `AD.md` → **architect-analyze**.
+6. **evals-init → evals-specify → evals-clarify → evals-implement →
+   evals-validate** — builds executable graders (binary Tier 1, LLM judge
+   Tier 2), holdout split, TPR/TNR + SLA validation. Pipeline ends at a
+   human-reviewed PR.
+7. **levelup-specify** — at session end, extracts hard-won fixes as CDRs +
+   paired eval CDRs. → **levelup-clarify** reviews → **levelup-publish**
+   commits to team repo → next session starts smarter.
+8. **team-repair --build-to-delete** — re-runs evals without a rule; if the
+   model passes anyway, proposes the rule for deletion. Rules shrink over
+   time, not grow.
+
+**The agent checks the directives index before any task.** Skills trigger
+automatically when the active task matches — mandatory lifecycle, not
+suggestions.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## What

Adds two new top-level README sections modeled on the [superpowers](https://github.com/obra/superpowers) README structure:

- **`## How it works`** — narrative tracing `team-boot` session-start index → `mission-brief` spec contract → `specify → plan → implement ↔ converge` → `product-*`/`architect-*` PDR/ADR compilation → `evals-*` graders → `levelup-*` CDR capture → `team-repair --build-to-delete` pruning.
- **`## The Basic Workflow`** — 8-step numbered list with bolded skill names; closing line: "skills trigger automatically — mandatory lifecycle, not suggestions."

Placed between "A note on context stuffing" and "Install" (mirrors superpowers: narrative → install). Tone matches the existing technical README. The collapsible `Workflows` `<details>` block and `Reference` table are unchanged.

## Why

A reader hit "Install" without ever seeing the end-to-end arc. The raw material existed (the `#1–#6` pain points, the `Workflows` details block, the `Reference` table) but no top-level narrative surfaced the flow. Superpowers' two-section pattern is the cleanest fix.

## Version

`0.26.0` → `0.26.1`. Documentation-only → **PATCH** per `RELEASE.md` ("PATCH: documentation updates"). `CHANGELOG.md` entry added.

## Release

Merging this PR to `main` triggers the **Auto-Tag Release** workflow, which creates the `adlc-team-skills-v0.26.1` annotated tag at the merge commit; the tag then triggers the **Release** workflow, which creates the GitHub release with `--latest` using notes extracted from the CHANGELOG section. No manual tagging needed.

## Checklist

- [x] CHANGELOG entry added at top with date + `### Added` section
- [x] README change is doc-only (no skill/script code touched)
- [x] Branch created from `main` (HEAD was at `v0.26.0` tag, no intervening commits)
- [x] Tracked `__pycache__/*.pyc` pytest artifacts restored (not committed)
- [ ] "Run Pytest" check passes
- [ ] Code-owner review + approval (required by `main` branch protection, `enforce_admins: true`)
