### PR TITLE
feat(levelup): merge trace into specify + boot.sh friction trigger

### DIFF
--- a/skills/levelup/levelup-specify/SKILL.md
+++ b/skills/levelup/levelup-specify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levelup-specify
-description: Extract Context Directive Records (CDRs) from the current session after completing work. Identifies reusable patterns (rules, personas, examples, evals) and captures directive compliance cases for team-ai-directives.
+description: Extract Context Directive Records (CDRs) from the current session after completing work. Reviews the session, writes an audit trace, and identifies reusable patterns (rules, personas, examples, evals) for team-ai-directives.
 disable-model-invocation: true
 ---
 
@@ -88,11 +88,12 @@ You are acting as a **Context Extractor** — identifying reusable patterns from
 
 1. **Environment Setup** (Phase 0): Resolve paths
 2. **Review Session** (Phase 1): Review the current session for patterns and evidence
-3. **Load Existing CDRs** (Phase 2): Read pending CDRs for enrichment
-4. **Extract Patterns** (Phase 3): Identify reusable patterns by context type + extract paired eval CDRs
-5. **Create/Enrich CDRs** (Phase 4): Write CDR files with session evidence
-6. **Regenerate Index** (Phase 5): Update `cdr.md`
-7. **Summary** (Phase 6): Present extraction results
+3. **Write Session Trace** (Phase 1.5): Write audit trail to `.adlc/drafts/trace.md`
+4. **Load Existing CDRs** (Phase 2): Read pending CDRs for enrichment
+5. **Extract Patterns** (Phase 3): Identify reusable patterns by context type + extract paired eval CDRs
+6. **Create/Enrich CDRs** (Phase 4): Write CDR files with session evidence
+7. **Regenerate Index** (Phase 5): Update `cdr.md`
+8. **Summary** (Phase 6): Present extraction results
 
 ### Execution Steps
 
@@ -123,7 +124,7 @@ Or set: export TEAM_AI_DIRECTIVES=/path/to/team-ai-directives
 
 #### Phase 1: Review Session
 
-Review the current session to identify what happened. The agent directly observes the session — no trace file is needed.
+Review the current session to identify what happened. The agent directly observes the session.
 
 1. What did the user ask for?
 2. What did the agent do? (file changes, key decisions, approach)
@@ -142,6 +143,29 @@ git log --oneline -10 2>/dev/null
 
 # New/untracked files
 git status --short 2>/dev/null
+```
+
+#### Phase 1.5: Write Session Trace
+
+Write a compact trace to `{REPO_ROOT}/.adlc/drafts/trace.md` for audit trail.
+
+```markdown
+# Session Trace
+
+Generated: [YYYY-MM-DD]
+Branch: [branch-name or "N/A"]
+
+## Summary
+
+[2-3 sentences: what was asked, what was done, outcome]
+
+## Key Decisions
+
+1. [Decision — rationale]
+
+## Files Changed
+
+- `[path]`: [what changed]
 ```
 
 #### Phase 2: Load Existing CDRs
@@ -363,7 +387,7 @@ Handoff context:
 ```text
 [Agent session — work completed]
     ↓
-/levelup-specify
+/levelup-specify  ← reviews session, writes trace, extracts CDRs
     ↓
 [Extract patterns + paired evals] → Write CDRs to .adlc/drafts/cdr/CDR-{NNN}.md (Proposed)
     ↓
@@ -381,6 +405,7 @@ After `/levelup-specify` completes, run `/levelup-clarify` to review the propose
 ## Verification
 
 - CDRs written to `{REPO_ROOT}/.adlc/drafts/cdr/CDR-{NNN}.md` with status **Proposed**.
+- Audit trace written to `{REPO_ROOT}/.adlc/drafts/trace.md`.
 - Auto-generated `cdr.md` index exists in `{REPO_ROOT}/.adlc/drafts/cdr/`.
 - Each CDR includes session implementation evidence.
 - Eval CDRs are paired with their directive CDRs and contain self-contained pass/fail cases.

--- a/skills/team/team-boot/scripts/boot.sh
+++ b/skills/team/team-boot/scripts/boot.sh
@@ -144,4 +144,31 @@ echo "| CDR-YYYY-NNN | <name> | <type> | <relevance> |"
 echo ""
 echo "Plus: _Searched $CDR_COUNT CDR entries, $PDR_COUNT PDR entries, $ADR_COUNT ADR entries, $CHDR_COUNT ChDR entries, $SKILL_TOTAL skills, J matched._"
 echo "**J MUST equal the number of rows in your table; if no CDRs/skills genuinely match, show an empty table with 0 matched (do not copy a hard-coded CDR or inflate the count).**"
+
+# Pending CDRs — remind user to clarify (safety net for missed suggestions)
+if [ -d ".adlc/drafts/cdr" ]; then
+  PENDING_CDRS=$(grep -rl "Status: \*\*Proposed\*\*" .adlc/drafts/cdr/CDR-*.md 2>/dev/null | wc -l)
+  if [ "$PENDING_CDRS" -gt 0 ]; then
+    echo ""
+    echo "## Pending CDRs"
+    echo "$PENDING_CDRS proposed CDR(s) awaiting review in \`.adlc/drafts/cdr/\`"
+    echo "Run \`/levelup-clarify\` to accept, reject, or defer them."
+  fi
+fi
+
+# Friction-based learning trigger (configurable, default on)
+CONTRIBUTE_HINT=true
+if [ -f "$INIT_FILE" ]; then
+  HINT_VAL=$(grep '"contribute_hint"' "$INIT_FILE" \
+    | sed 's/.*"contribute_hint"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/' \
+    | head -1)
+  [ -n "$HINT_VAL" ] && CONTRIBUTE_HINT="$HINT_VAL"
+fi
+if [ "$CONTRIBUTE_HINT" = "true" ]; then
+  echo ""
+  echo "## Session Friction Awareness"
+  echo "After completing work that involved problem-solving friction — retries, corrections, unexpected failures, or significant debugging — proactively suggest running \`/levelup-specify\` to extract reusable patterns."
+  echo "Do NOT suggest for routine work. At most one suggestion per task completion."
+fi
+
 echo "</EXTREMELY_IMPORTANT>"

--- a/skills/team/team-boot/scripts/boot.sh
+++ b/skills/team/team-boot/scripts/boot.sh
@@ -147,7 +147,7 @@ echo "**J MUST equal the number of rows in your table; if no CDRs/skills genuine
 
 # Pending CDRs — remind user to clarify (safety net for missed suggestions)
 if [ -d ".adlc/drafts/cdr" ]; then
-  PENDING_CDRS=$(grep -rl "Status: \*\*Proposed\*\*" .adlc/drafts/cdr/CDR-*.md 2>/dev/null | wc -l)
+  PENDING_CDRS=$(grep -rl "Status: \*\*Proposed\*\*" .adlc/drafts/cdr/CDR-*.md 2>/dev/null | wc -l || true)
   if [ "$PENDING_CDRS" -gt 0 ]; then
     echo ""
     echo "## Pending CDRs"
@@ -159,9 +159,9 @@ fi
 # Friction-based learning trigger (configurable, default on)
 CONTRIBUTE_HINT=true
 if [ -f "$INIT_FILE" ]; then
-  HINT_VAL=$(grep '"contribute_hint"' "$INIT_FILE" \
+  HINT_VAL=$(grep '"contribute_hint"' "$INIT_FILE" 2>/dev/null \
     | sed 's/.*"contribute_hint"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/' \
-    | head -1)
+    | head -1 || true)
   [ -n "$HINT_VAL" ] && CONTRIBUTE_HINT="$HINT_VAL"
 fi
 if [ "$CONTRIBUTE_HINT" = "true" ]; then


### PR DESCRIPTION
## Summary

Adapted from Tencent/teamai-cli's session friction scoring model. Unlike teamai-cli's Stop hook, opencode has no `session_end` event, so the LLM self-assesses friction at task completion and suggests `/levelup-specify` (explicit user invocation, not auto-run).

## Changes

### `skills/levelup/levelup-specify/SKILL.md` (+41/-8)
- **New Phase 1.5**: Write Session Trace — always writes `.adlc/drafts/trace.md` as audit artifact (replaces the separate `/levelup-trace` skill)
- Updated outline, workflow diagram, description, and verification to reflect merged trace+specify
- Removed `levelup-trace` as a prerequisite — `levelup-specify` reviews the session directly

### `skills/team/team-boot/scripts/boot.sh` (+27)
- **Friction self-trigger instruction**: injects "suggest `/levelup-specify` after friction-heavy work" into session context
  - Configurable via `contribute_hint` in `.adlc/init-options.json` (default: `true`)
  - LLM self-assesses at task completion — no event hook needed
- **Pending CDRs safety net**: scans `.adlc/drafts/cdr/` for Proposed CDRs on session start, reminds user to run `/levelup-clarify`

## What stays unchanged
- `.events.json` — no new event hook
- `adlc-skills-events.ts` — no plugin changes
- `levelup-clarify`, `levelup-publish`, `levelup-init` — unchanged
- CDR.md / OKF pipeline — unchanged
- `team-boot/SKILL.md` frontmatter — unchanged

## Design decisions
1. **Pending CDRs reminder** fires at session start only (via boot.sh), not mid-session
2. **Trigger** is explicit — LLM suggests, user invokes `/levelup-specify` (Constitution Principle #1: Human Oversight)
3. **Trace** is always written as built-in Phase 1.5 in levelup-specify (mandatory)
4. **No backward compat** — `levelup-trace` user-level skill deleted, not deprecated