### PR TITLE
feat(team-boot): ADR/PDR session friction guardrails

### DIFF
--- a/skills/levelup/levelup-specify/SKILL.md
+++ b/skills/levelup/levelup-specify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levelup-specify
-description: Extract Context Directive Records (CDRs) from the current session after completing work. Identifies reusable patterns (rules, personas, examples, evals) and captures directive compliance cases for team-ai-directives.
+description: Extract Context Directive Records (CDRs) from the current session after completing work. Reviews the session, writes an audit trace, and identifies reusable patterns (rules, personas, examples, evals) for team-ai-directives.
 disable-model-invocation: true
 ---
 
@@ -88,11 +88,12 @@ You are acting as a **Context Extractor** — identifying reusable patterns from
 
 1. **Environment Setup** (Phase 0): Resolve paths
 2. **Review Session** (Phase 1): Review the current session for patterns and evidence
-3. **Load Existing CDRs** (Phase 2): Read pending CDRs for enrichment
-4. **Extract Patterns** (Phase 3): Identify reusable patterns by context type + extract paired eval CDRs
-5. **Create/Enrich CDRs** (Phase 4): Write CDR files with session evidence
-6. **Regenerate Index** (Phase 5): Update `cdr.md`
-7. **Summary** (Phase 6): Present extraction results
+3. **Write Session Trace** (Phase 1.5): Write audit trail to `.adlc/drafts/trace.md`
+4. **Load Existing CDRs** (Phase 2): Read pending CDRs for enrichment
+5. **Extract Patterns** (Phase 3): Identify reusable patterns by context type + extract paired eval CDRs
+6. **Create/Enrich CDRs** (Phase 4): Write CDR files with session evidence
+7. **Regenerate Index** (Phase 5): Update `cdr.md`
+8. **Summary** (Phase 6): Present extraction results
 
 ### Execution Steps
 
@@ -123,7 +124,7 @@ Or set: export TEAM_AI_DIRECTIVES=/path/to/team-ai-directives
 
 #### Phase 1: Review Session
 
-Review the current session to identify what happened. The agent directly observes the session — no trace file is needed.
+Review the current session to identify what happened. The agent directly observes the session.
 
 1. What did the user ask for?
 2. What did the agent do? (file changes, key decisions, approach)
@@ -142,6 +143,29 @@ git log --oneline -10 2>/dev/null
 
 # New/untracked files
 git status --short 2>/dev/null
+```
+
+#### Phase 1.5: Write Session Trace
+
+Write a compact trace to `{REPO_ROOT}/.adlc/drafts/trace.md` for audit trail.
+
+```markdown
+# Session Trace
+
+Generated: [YYYY-MM-DD]
+Branch: [branch-name or "N/A"]
+
+## Summary
+
+[2-3 sentences: what was asked, what was done, outcome]
+
+## Key Decisions
+
+1. [Decision — rationale]
+
+## Files Changed
+
+- `[path]`: [what changed]
 ```
 
 #### Phase 2: Load Existing CDRs
@@ -363,7 +387,7 @@ Handoff context:
 ```text
 [Agent session — work completed]
     ↓
-/levelup-specify
+/levelup-specify  ← reviews session, writes trace, extracts CDRs
     ↓
 [Extract patterns + paired evals] → Write CDRs to .adlc/drafts/cdr/CDR-{NNN}.md (Proposed)
     ↓
@@ -381,6 +405,7 @@ After `/levelup-specify` completes, run `/levelup-clarify` to review the propose
 ## Verification
 
 - CDRs written to `{REPO_ROOT}/.adlc/drafts/cdr/CDR-{NNN}.md` with status **Proposed**.
+- Audit trace written to `{REPO_ROOT}/.adlc/drafts/trace.md`.
 - Auto-generated `cdr.md` index exists in `{REPO_ROOT}/.adlc/drafts/cdr/`.
 - Each CDR includes session implementation evidence.
 - Eval CDRs are paired with their directive CDRs and contain self-contained pass/fail cases.

--- a/skills/team/team-boot/SKILL.md
+++ b/skills/team/team-boot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-boot
-description: Bootstrap the session with team AI directives context (constitution, CDR index, PDR/ADR/ChDR indexes, skill registry). Runs automatically at session start via the event hook.
+description: Bootstrap the session with team AI directives context (constitution, CDR index, PDR/ADR/ChDR indexes, skill registry). Includes session-end friction trigger for CDR/ADR/PDR capture and pending-decision safety nets. Runs automatically at session start via the event hook.
 scripts:
   sh: scripts/boot.sh
   ps: scripts/boot.ps1

--- a/skills/team/team-boot/scripts/boot.sh
+++ b/skills/team/team-boot/scripts/boot.sh
@@ -144,4 +144,31 @@ echo "| CDR-YYYY-NNN | <name> | <type> | <relevance> |"
 echo ""
 echo "Plus: _Searched $CDR_COUNT CDR entries, $PDR_COUNT PDR entries, $ADR_COUNT ADR entries, $CHDR_COUNT ChDR entries, $SKILL_TOTAL skills, J matched._"
 echo "**J MUST equal the number of rows in your table; if no CDRs/skills genuinely match, show an empty table with 0 matched (do not copy a hard-coded CDR or inflate the count).**"
+
+# Pending CDRs — remind user to clarify (safety net for missed suggestions)
+if [ -d ".adlc/drafts/cdr" ]; then
+  PENDING_CDRS=$(grep -rl "Status: \*\*Proposed\*\*" .adlc/drafts/cdr/CDR-*.md 2>/dev/null | wc -l)
+  if [ "$PENDING_CDRS" -gt 0 ]; then
+    echo ""
+    echo "## Pending CDRs"
+    echo "$PENDING_CDRS proposed CDR(s) awaiting review in \`.adlc/drafts/cdr/\`"
+    echo "Run \`/levelup-clarify\` to accept, reject, or defer them."
+  fi
+fi
+
+# Friction-based learning trigger (configurable, default on)
+CONTRIBUTE_HINT=true
+if [ -f "$INIT_FILE" ]; then
+  HINT_VAL=$(grep '"contribute_hint"' "$INIT_FILE" \
+    | sed 's/.*"contribute_hint"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/' \
+    | head -1)
+  [ -n "$HINT_VAL" ] && CONTRIBUTE_HINT="$HINT_VAL"
+fi
+if [ "$CONTRIBUTE_HINT" = "true" ]; then
+  echo ""
+  echo "## Session Friction Awareness"
+  echo "After completing work that involved problem-solving friction — retries, corrections, unexpected failures, or significant debugging — proactively suggest running \`/levelup-specify\` to extract reusable patterns."
+  echo "Do NOT suggest for routine work. At most one suggestion per task completion."
+fi
+
 echo "</EXTREMELY_IMPORTANT>"

--- a/skills/team/team-boot/scripts/boot.sh
+++ b/skills/team/team-boot/scripts/boot.sh
@@ -156,6 +156,28 @@ if [ -d ".adlc/drafts/cdr" ]; then
   fi
 fi
 
+# Pending ADRs — remind user to clarify
+if [ -d ".adlc/drafts/adr" ]; then
+  PENDING_ADRS=$(grep -rl "status: proposed\|Status: Proposed" .adlc/drafts/adr/ADR-*.md 2>/dev/null | wc -l || true)
+  if [ "$PENDING_ADRS" -gt 0 ]; then
+    echo ""
+    echo "## Pending ADRs"
+    echo "$PENDING_ADRS proposed ADR(s) awaiting review in \`.adlc/drafts/adr/\`"
+    echo "Run \`/architect-clarify\` to accept, reject, or defer them."
+  fi
+fi
+
+# Pending PDRs — remind user to clarify
+if [ -d ".adlc/drafts/pdr" ]; then
+  PENDING_PDRS=$(grep -rl "status: proposed\|Status: Proposed" .adlc/drafts/pdr/PDR-*.md 2>/dev/null | wc -l || true)
+  if [ "$PENDING_PDRS" -gt 0 ]; then
+    echo ""
+    echo "## Pending PDRs"
+    echo "$PENDING_PDRS proposed PDR(s) awaiting review in \`.adlc/drafts/pdr/\`"
+    echo "Run \`/product-clarify\` to accept, reject, or defer them."
+  fi
+fi
+
 # Friction-based learning trigger (configurable, default on)
 CONTRIBUTE_HINT=true
 if [ -f "$INIT_FILE" ]; then
@@ -167,7 +189,15 @@ fi
 if [ "$CONTRIBUTE_HINT" = "true" ]; then
   echo ""
   echo "## Session Friction Awareness"
-  echo "After completing work that involved problem-solving friction — retries, corrections, unexpected failures, or significant debugging — proactively suggest running \`/levelup-specify\` to extract reusable patterns."
+  echo "After completing significant work, self-assess for decision drift:"
+  echo ""
+  echo "1. **CDR friction** — reusable patterns, novel approaches, or significant debugging emerged → suggest \`/levelup-specify\`"
+  echo "2. **ADR gap** — new architectural concern not covered by existing ADRs → suggest \`/architect-specify\`"
+  echo "3. **ADR violation** — work contradicts an accepted ADR → suggest \`/architect-clarify\`"
+  echo "4. **PDR gap** — new product decision not covered by existing PDRs → suggest \`/product-specify\`"
+  echo "5. **PDR violation** — work contradicts an accepted PDR → suggest \`/product-clarify\`"
+  echo ""
+  echo "Guardrail: Before assessing ADR/PDR alignment, read relevant ADR/PDR files from \`.adlc/memory/adr/\` and \`.adlc/memory/pdr/\` if not already loaded."
   echo "Do NOT suggest for routine work. At most one suggestion per task completion."
 fi
 

--- a/skills/team/team-boot/scripts/boot.sh
+++ b/skills/team/team-boot/scripts/boot.sh
@@ -147,7 +147,7 @@ echo "**J MUST equal the number of rows in your table; if no CDRs/skills genuine
 
 # Pending CDRs — remind user to clarify (safety net for missed suggestions)
 if [ -d ".adlc/drafts/cdr" ]; then
-  PENDING_CDRS=$(grep -rl "Status: \*\*Proposed\*\*" .adlc/drafts/cdr/CDR-*.md 2>/dev/null | wc -l)
+  PENDING_CDRS=$(grep -rl "Status: \*\*Proposed\*\*" .adlc/drafts/cdr/CDR-*.md 2>/dev/null | wc -l || true)
   if [ "$PENDING_CDRS" -gt 0 ]; then
     echo ""
     echo "## Pending CDRs"
@@ -159,9 +159,9 @@ fi
 # Friction-based learning trigger (configurable, default on)
 CONTRIBUTE_HINT=true
 if [ -f "$INIT_FILE" ]; then
-  HINT_VAL=$(grep '"contribute_hint"' "$INIT_FILE" \
+  HINT_VAL=$(grep '"contribute_hint"' "$INIT_FILE" 2>/dev/null \
     | sed 's/.*"contribute_hint"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/' \
-    | head -1)
+    | head -1 || true)
   [ -n "$HINT_VAL" ] && CONTRIBUTE_HINT="$HINT_VAL"
 fi
 if [ "$CONTRIBUTE_HINT" = "true" ]; then


### PR DESCRIPTION
Extends PR #28 (feat/session-friction-trigger) to cover architecture and product decision records alongside CDRs.

## Changes

### `skills/team/team-boot/scripts/boot.sh` (+30/-2)

- **Unified friction trigger**: Expands CDR-only self-assessment to 5-point CDR+ADR+PDR alignment check
  - CDR friction → suggest `/levelup-specify`
  - ADR gap → suggest `/architect-specify`
  - ADR violation → suggest `/architect-clarify`
  - PDR gap → suggest `/product-specify`
  - PDR violation → suggest `/product-clarify`
  - Guardrail: instruct LLM to read relevant ADR/PDR files before assessing
- **Pending ADR safety net**: scans `.adlc/drafts/adr/` for Proposed ADRs on session start, reminds user to run `/architect-clarify`
- **Pending PDR safety net**: scans `.adlc/drafts/pdr/` for Proposed PDRs on session start, reminds user to run `/product-clarify`

### `skills/team/team-boot/SKILL.md` (+1/-1)

- Update frontmatter description to mention ADR/PDR capture and pending-decision safety nets

## Design decisions

1. **No changes to levelup-specify** — ADR/PDR alignment is architect/product domain, not levelup
2. **Unconditional pending reminders** — same behavior as CDRs (fire whenever Proposed records exist)
3. **`|| true` on grep** — handles `pipefail` when no Proposed records found (same fix as PR #28 commit `16908e4`)
4. **Same `contribute_hint` config** — unified trigger respects the same init-options.json flag

## What stays unchanged

- `levelup-specify/SKILL.md` — no ADR/PDR coverage (stays CDR-only)
- `.events.json` — no new event hook
- CDR pending reminder and CDR friction trigger behavior
